### PR TITLE
Fix broken title when post format icon is present

### DIFF
--- a/archived-post-status.php
+++ b/archived-post-status.php
@@ -242,8 +242,7 @@ function aps_edit_screen_js() {
 		function disallowEditing( $row ) {
 			var title = $row.find( '.column-title a.row-title' ).text();
 
-			$row.find( '.column-title a.row-title' ).remove();
-			$row.find( '.column-title strong' ).prepend( title );
+			$row.find( '.column-title a.row-title' ).replaceWith( title );
 			$row.find( '.row-actions .edit' ).remove();
 		}
 	});


### PR DESCRIPTION
This fix will ensure that the A tag is replaced with the inactive title, without breaking the post format image link before the title.

Resolved by changing the two remove() and prepend() DOM functions with a single replaceWith() function.
