### PR TITLE
v0.3.9 - Bugfixes & updates

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,10 @@
-# Directories
 /.wordpress-org export-ignore
 /.github export-ignore
-# Files
+/tests/ export-ignore
 /.gitattributes export-ignore
 /.gitignore export-ignore
+/.distignore export-ignore
+/contributing.md export-ignore
+/phpstan.neon.dist export-ignore
+/code-of-conduct.md export-ignore
+/.wp-env.json export-ignore

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        php: ['7.4', '8.0', '8.1', '8.2.' ]
+        php: ['7.4', '8.0', '8.1', '8.2.']
     steps:
     - name: "Checkout"
       uses: "actions/checkout@v3"

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -1,0 +1,35 @@
+name: "Unit Tests"
+
+on:
+  pull_request: null
+  push:
+    branches:
+      - stable
+      - develop
+
+jobs:
+  phpunit:
+    name: ${{ matrix.php-versions }} PHPUnit Tests
+    runs-on: "ubuntu-latest"
+    strategy:
+      matrix:
+        php-versions: [ '8.1', '8.2' ]
+
+    steps:
+    - name: "Checkout"
+      uses: "actions/checkout@v3"
+
+    - name: "Set PHP version"
+      uses: "shivammathur/setup-php@v2"
+      with:
+        php-version: ${{ matrix.php-versions }}
+        coverage: none
+        tools: phpunit, phpunit-polyfills, composer:v2
+      env:
+        debug: true
+
+    - name: "Install dependencies"
+      run: "composer install"
+
+    - name: "PHPUnit Tests"
+      run: './vendor/bin/phpunit'

--- a/archived-post-status.php
+++ b/archived-post-status.php
@@ -24,11 +24,9 @@
  */
 
 /**
- * Exit if accessed directly.
+ * Exit if accessed directly, prevent direct access to this file.
  *
- * Prevent direct access to this file.
- *
- * @since 0.1.0
+ * @since 0.3.9
  */
 if ( ! defined( 'ABSPATH' ) ) {
 	die;

--- a/archived-post-status.php
+++ b/archived-post-status.php
@@ -7,7 +7,7 @@
  * registers the activation and deactivation functions, and defines a function
  * that starts the plugin.
  *
- * @link    https://github.com/joshuadavidnelson/disable-blog
+ * @link    https://github.com/joshuadavidnelson/archived-post-status
  * @since   0.3.8
  * @package ArchivedPostStatus
  *

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 ---
 
 ## 0.3.9 - 
-- Fix deprecated php warning on `filter_input`, using native WP functions for escaping & getting query var.
+- Fix deprecated php warning on `filter_input`, using native WP functions for escaping & getting query var. Fixes another issue, where archived posts couldn't be trashed (Closes #35)
 - Add `aps_archived_label_string` filter to modify the "Archived" string used for the label.
 - Add `aps_title_separator` and `aps_title_label` to filter the post title prefix and separator, defaults to 'Archived' with a `:` separator. Disable the title label entirely by using `add_filter( 'aps_title_prefix', '__return_false' );` in your `functions.php` file or custom plugin file. Closes #21
 - Added `aps_title_label_before` filter, defaults to `true` - pass `false` to have the label appear after the title instead of before it. This change along with the label string filter above closes #31

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
 - Add `aps_archived_label_string` filter to modify the "Archived" string used for the label.
 - Add `aps_title_separator` and `aps_title_label` to filter the post title prefix and separator, defaults to 'Archived' with a `:` separator. Disable the title prefix entirely by using `add_filter( 'aps_title_prefix', '__return_false' );` in your functions.php file or custom plugin file. Closes #21
 - Added `aps_title_label_before` filter, defaults to `true` - pass `false` to have the label appear after the title instead of before it. This change along with the label string filter above closes #31
+- Add PHPUnit tests & github actions.
 - Update some comments and documentation, readmes, etc
 
 ## 0.3.8 - December 15, 2023
@@ -14,11 +15,11 @@ Ownership of this plugin is being transferred to [Joshua David Nelson](https://g
 
 This update includes:
 - Tested up to WordPress 6.4.2
-- Added minimum PHP of 7.4
-- Bumped minimum WordPress to 5.3
-- Added Github actions for deployment to WP repo
-- Updated contributors in readmes
-- Added PHPStan and PHPCS Github actions
+- Add minimum PHP of 7.4
+- Bump minimum WordPress to 5.3
+- Add Github actions for deployment to WP repo
+- Update contributors in readmes
+- Add PHPStan and PHPCS Github actions
 
 ## 0.3.7 - December 23, 2016
 * Tweak: Indicate support for WordPress 4.7.

--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,7 @@
 ## 0.3.9 - 
 - Fix deprecated php warning on `filter_input`, using native WP functions for escaping & getting query var.
 - Add `aps_archived_label_string` filter to modify the "Archived" string used for the label.
-- Add `aps_title_separator` and `aps_title_label` to filter the post title prefix and separator, defaults to 'Archived' with a `:` separator. Disable the title prefix entirely by using `add_filter( 'aps_title_prefix', '__return_false' );` in your functions.php file or custom plugin file. Closes #21
+- Add `aps_title_separator` and `aps_title_label` to filter the post title prefix and separator, defaults to 'Archived' with a `:` separator. Disable the title label entirely by using `add_filter( 'aps_title_prefix', '__return_false' );` in your `functions.php` file or custom plugin file. Closes #21
 - Added `aps_title_label_before` filter, defaults to `true` - pass `false` to have the label appear after the title instead of before it. This change along with the label string filter above closes #31
 - Add PHPUnit tests & github actions.
 - Update some comments and documentation, readmes, etc

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,13 @@
 # Archived Post Status Changelog
 ---
 
+## 0.3.9 - 
+- Fix deprecated php warning on `filter_input`, using native WP functions for escaping & getting query var.
+- Add `aps_archived_label_string` filter to modify the "Archived" string used for the label.
+- Add `aps_title_separator` and `aps_title_label` to filter the post title prefix and separator, defaults to 'Archived' with a `:` separator. Disable the title prefix entirely by using `add_filter( 'aps_title_prefix', '__return_false' );` in your functions.php file or custom plugin file. Closes #21
+- Added `aps_title_label_before` filter, defaults to `true` - pass `false` to have the label appear after the title instead of before it. This change along with the label string filter above closes #31
+- Update some comments and documentation, readmes, etc
+
 ## 0.3.8 - December 15, 2023
 
 Ownership of this plugin is being transferred to [Joshua David Nelson](https://github.com/joshuadavidnelson/). A huge thank you to @fjarrett for his work on this plugin to this point. More info to come soon!

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,29 @@
+{
+	"name": "joshuadavidnelson/archived-post-status",
+	"type": "wordpress-plugin",
+	"description": "A WordPress plugin that allows posts and pages to be archived so you can unpublish content without having to trash it.",
+	"homepage": "https://archivedpoststat.us/",
+	"license": "GPL-2.0-or-later",
+	"authors": [
+	  {
+		"name": "joshuadavidnelson",
+		"email": "josh@joshuadnelson.com"
+	  }
+	],
+	"require": {
+	  "php": ">=7.4"
+	},
+	"require-dev": {
+	  "10up/phpcs-composer": "dev-master",
+	  "phpunit/phpunit": "^9.5.24",
+	  "10up/wp_mock": "^0.5.0",
+	  "yoast/phpunit-polyfills": "^1.0"
+	},
+	"prefer-stable": true,
+	"config": {
+	  "allow-plugins": {
+			"composer/installers": true,
+			"dealerdirect/phpcodesniffer-composer-installer": true
+		}
+	}
+  }

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,2567 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "5e90e78af9be9fb19331a5be546255ec",
+    "packages": [],
+    "packages-dev": [
+        {
+            "name": "10up/phpcs-composer",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/10up/phpcs-composer.git",
+                "reference": "4a2f47d5ed0493836ef33ee2edad32192699fad6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/10up/phpcs-composer/zipball/4a2f47d5ed0493836ef33ee2edad32192699fad6",
+                "reference": "4a2f47d5ed0493836ef33ee2edad32192699fad6",
+                "shasum": ""
+            },
+            "require": {
+                "automattic/vipwpcs": "^2.3",
+                "dealerdirect/phpcodesniffer-composer-installer": "*",
+                "phpcompatibility/phpcompatibility-wp": "^2",
+                "squizlabs/php_codesniffer": "3.7.1",
+                "wp-coding-standards/wpcs": "*"
+            },
+            "default-branch": true,
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "10up",
+                    "homepage": "https://10up.com/"
+                }
+            ],
+            "description": "10up's PHP CodeSniffer Ruleset",
+            "support": {
+                "issues": "https://github.com/10up/phpcs-composer/issues",
+                "source": "https://github.com/10up/phpcs-composer/tree/2.0.1"
+            },
+            "time": "2023-09-14T12:16:59+00:00"
+        },
+        {
+            "name": "10up/wp_mock",
+            "version": "0.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/10up/wp_mock.git",
+                "reference": "5cd57c63b1a946301ce0d7aaaa37cdc25805c163"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/10up/wp_mock/zipball/5cd57c63b1a946301ce0d7aaaa37cdc25805c163",
+                "reference": "5cd57c63b1a946301ce0d7aaaa37cdc25805c163",
+                "shasum": ""
+            },
+            "require": {
+                "antecedent/patchwork": "^2.1",
+                "mockery/mockery": "^1.5",
+                "php": ">=7.3 < 9.0",
+                "phpunit/phpunit": "^9.5.24"
+            },
+            "require-dev": {
+                "behat/behat": "^v3.11.0",
+                "php-coveralls/php-coveralls": "^v2.5.3",
+                "sebastian/comparator": "^4.0.8",
+                "sempro/phpunit-pretty-print": "^1.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "WP_Mock\\": "./php/WP_Mock"
+                },
+                "classmap": [
+                    "php/WP_Mock.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "A mocking library to take the pain out of unit testing for WordPress",
+            "support": {
+                "issues": "https://github.com/10up/wp_mock/issues",
+                "source": "https://github.com/10up/wp_mock/tree/0.5.0"
+            },
+            "time": "2022-11-01T03:01:40+00:00"
+        },
+        {
+            "name": "antecedent/patchwork",
+            "version": "2.1.27",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/antecedent/patchwork.git",
+                "reference": "16a1ab81559aabf14acb616141e801b32777f085"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/antecedent/patchwork/zipball/16a1ab81559aabf14acb616141e801b32777f085",
+                "reference": "16a1ab81559aabf14acb616141e801b32777f085",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": ">=4"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ignas Rudaitis",
+                    "email": "ignas.rudaitis@gmail.com"
+                }
+            ],
+            "description": "Method redefinition (monkey-patching) functionality for PHP.",
+            "homepage": "https://antecedent.github.io/patchwork/",
+            "keywords": [
+                "aop",
+                "aspect",
+                "interception",
+                "monkeypatching",
+                "redefinition",
+                "runkit",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/antecedent/patchwork/issues",
+                "source": "https://github.com/antecedent/patchwork/tree/2.1.27"
+            },
+            "time": "2023-12-03T18:46:49+00:00"
+        },
+        {
+            "name": "automattic/vipwpcs",
+            "version": "2.3.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/VIP-Coding-Standards.git",
+                "reference": "b8610e3837f49c5f2fcc4b663b6c0a7c9b3509b6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/VIP-Coding-Standards/zipball/b8610e3837f49c5f2fcc4b663b6c0a7c9b3509b6",
+                "reference": "b8610e3837f49c5f2fcc4b663b6c0a7c9b3509b6",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0",
+                "php": ">=5.4",
+                "sirbrillig/phpcs-variable-analysis": "^2.11.17",
+                "squizlabs/php_codesniffer": "^3.7.1",
+                "wp-coding-standards/wpcs": "^2.3"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "phpcompatibility/php-compatibility": "^9",
+                "phpcsstandards/phpcsdevtools": "^1.0",
+                "phpunit/phpunit": "^4 || ^5 || ^6 || ^7"
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/Automattic/VIP-Coding-Standards/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer rules (sniffs) to enforce WordPress VIP minimum coding conventions",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "static analysis",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/Automattic/VIP-Coding-Standards/issues",
+                "source": "https://github.com/Automattic/VIP-Coding-Standards",
+                "wiki": "https://github.com/Automattic/VIP-Coding-Standards/wiki"
+            },
+            "time": "2023-08-24T15:11:13+00:00"
+        },
+        {
+            "name": "dealerdirect/phpcodesniffer-composer-installer",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/composer-installer.git",
+                "reference": "4be43904336affa5c2f70744a348312336afd0da"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/4be43904336affa5c2f70744a348312336afd0da",
+                "reference": "4be43904336affa5c2f70744a348312336afd0da",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^2.0 || ^3.1.0 || ^4.0"
+            },
+            "require-dev": {
+                "composer/composer": "*",
+                "ext-json": "*",
+                "ext-zip": "*",
+                "php-parallel-lint/php-parallel-lint": "^1.3.1",
+                "phpcompatibility/php-compatibility": "^9.0",
+                "yoast/phpunit-polyfills": "^1.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Franck Nijhof",
+                    "email": "franck.nijhof@dealerdirect.com",
+                    "homepage": "http://www.frenck.nl",
+                    "role": "Developer / IT Manager"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/composer-installer/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
+            "homepage": "http://www.dealerdirect.com",
+            "keywords": [
+                "PHPCodeSniffer",
+                "PHP_CodeSniffer",
+                "code quality",
+                "codesniffer",
+                "composer",
+                "installer",
+                "phpcbf",
+                "phpcs",
+                "plugin",
+                "qa",
+                "quality",
+                "standard",
+                "standards",
+                "style guide",
+                "stylecheck",
+                "tests"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/composer-installer/issues",
+                "source": "https://github.com/PHPCSStandards/composer-installer"
+            },
+            "time": "2023-01-05T11:28:13+00:00"
+        },
+        {
+            "name": "doctrine/instantiator",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/instantiator.git",
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^11",
+                "ext-pdo": "*",
+                "ext-phar": "*",
+                "phpbench/phpbench": "^1.2",
+                "phpstan/phpstan": "^1.9.4",
+                "phpstan/phpstan-phpunit": "^1.3",
+                "phpunit/phpunit": "^9.5.27",
+                "vimeo/psalm": "^5.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "https://ocramius.github.io/"
+                }
+            ],
+            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
+            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
+            "keywords": [
+                "constructor",
+                "instantiate"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/instantiator/issues",
+                "source": "https://github.com/doctrine/instantiator/tree/2.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-12-30T00:23:10+00:00"
+        },
+        {
+            "name": "hamcrest/hamcrest-php",
+            "version": "v2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/hamcrest/hamcrest-php.git",
+                "reference": "8c3d0a3f6af734494ad8f6fbbee0ba92422859f3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/hamcrest/hamcrest-php/zipball/8c3d0a3f6af734494ad8f6fbbee0ba92422859f3",
+                "reference": "8c3d0a3f6af734494ad8f6fbbee0ba92422859f3",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3|^7.0|^8.0"
+            },
+            "replace": {
+                "cordoval/hamcrest-php": "*",
+                "davedevelopment/hamcrest-php": "*",
+                "kodova/hamcrest-php": "*"
+            },
+            "require-dev": {
+                "phpunit/php-file-iterator": "^1.4 || ^2.0",
+                "phpunit/phpunit": "^4.8.36 || ^5.7 || ^6.5 || ^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "hamcrest"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "This is the PHP port of Hamcrest Matchers",
+            "keywords": [
+                "test"
+            ],
+            "support": {
+                "issues": "https://github.com/hamcrest/hamcrest-php/issues",
+                "source": "https://github.com/hamcrest/hamcrest-php/tree/v2.0.1"
+            },
+            "time": "2020-07-09T08:09:16+00:00"
+        },
+        {
+            "name": "mockery/mockery",
+            "version": "1.6.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mockery/mockery.git",
+                "reference": "0cc058854b3195ba21dc6b1f7b1f60f4ef3a9c06"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mockery/mockery/zipball/0cc058854b3195ba21dc6b1f7b1f60f4ef3a9c06",
+                "reference": "0cc058854b3195ba21dc6b1f7b1f60f4ef3a9c06",
+                "shasum": ""
+            },
+            "require": {
+                "hamcrest/hamcrest-php": "^2.0.1",
+                "lib-pcre": ">=7.0",
+                "php": ">=7.3"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.5 || ^9.6.10",
+                "symplify/easy-coding-standard": "^12.0.8"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "library/helpers.php",
+                    "library/Mockery.php"
+                ],
+                "psr-4": {
+                    "Mockery\\": "library/Mockery"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Pádraic Brady",
+                    "email": "padraic.brady@gmail.com",
+                    "homepage": "https://github.com/padraic",
+                    "role": "Author"
+                },
+                {
+                    "name": "Dave Marshall",
+                    "email": "dave.marshall@atstsolutions.co.uk",
+                    "homepage": "https://davedevelopment.co.uk",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Nathanael Esayeas",
+                    "email": "nathanael.esayeas@protonmail.com",
+                    "homepage": "https://github.com/ghostwriter",
+                    "role": "Lead Developer"
+                }
+            ],
+            "description": "Mockery is a simple yet flexible PHP mock object framework",
+            "homepage": "https://github.com/mockery/mockery",
+            "keywords": [
+                "BDD",
+                "TDD",
+                "library",
+                "mock",
+                "mock objects",
+                "mockery",
+                "stub",
+                "test",
+                "test double",
+                "testing"
+            ],
+            "support": {
+                "docs": "https://docs.mockery.io/",
+                "issues": "https://github.com/mockery/mockery/issues",
+                "rss": "https://github.com/mockery/mockery/releases.atom",
+                "security": "https://github.com/mockery/mockery/security/advisories",
+                "source": "https://github.com/mockery/mockery"
+            },
+            "time": "2023-12-10T02:24:34+00:00"
+        },
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.11.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "7284c22080590fb39f2ffa3e9057f10a4ddd0e0c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/7284c22080590fb39f2ffa3e9057f10a4ddd0e0c",
+                "reference": "7284c22080590fb39f2ffa3e9057f10a4ddd0e0c",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3,<3.2.2"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.11.1"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-03-08T13:26:56+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v4.18.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "1bcbb2179f97633e98bbbc87044ee2611c7d7999"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/1bcbb2179f97633e98bbbc87044ee2611c7d7999",
+                "reference": "1bcbb2179f97633e98bbbc87044ee2611c7d7999",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0 || ^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.18.0"
+            },
+            "time": "2023-12-10T21:03:43+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "97803eca37d319dfa7826cc2437fc020857acb53"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/97803eca37d319dfa7826cc2437fc020857acb53",
+                "reference": "97803eca37d319dfa7826cc2437fc020857acb53",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-phar": "*",
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/2.0.3"
+            },
+            "time": "2021-07-20T11:28:43+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/3.2.1"
+            },
+            "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpcompatibility/php-compatibility",
+            "version": "9.3.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
+                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/9fb324479acf6f39452e0655d2429cc0d3914243",
+                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.3 || ^3.0.2"
+            },
+            "conflict": {
+                "squizlabs/php_codesniffer": "2.6.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "homepage": "https://github.com/wimg",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCompatibility/PHPCompatibility/graphs/contributors"
+                }
+            ],
+            "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP cross-version compatibility.",
+            "homepage": "http://techblog.wimgodden.be/tag/codesniffer/",
+            "keywords": [
+                "compatibility",
+                "phpcs",
+                "standards"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibility/issues",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibility"
+            },
+            "time": "2019-12-27T09:44:58+00:00"
+        },
+        {
+            "name": "phpcompatibility/phpcompatibility-paragonie",
+            "version": "1.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie.git",
+                "reference": "bba5a9dfec7fcfbd679cfaf611d86b4d3759da26"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/bba5a9dfec7fcfbd679cfaf611d86b4d3759da26",
+                "reference": "bba5a9dfec7fcfbd679cfaf611d86b4d3759da26",
+                "shasum": ""
+            },
+            "require": {
+                "phpcompatibility/php-compatibility": "^9.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
+                "paragonie/random_compat": "dev-master",
+                "paragonie/sodium_compat": "dev-master"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "lead"
+                }
+            ],
+            "description": "A set of rulesets for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by the Paragonie polyfill libraries.",
+            "homepage": "http://phpcompatibility.com/",
+            "keywords": [
+                "compatibility",
+                "paragonie",
+                "phpcs",
+                "polyfill",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie/issues",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie"
+            },
+            "time": "2022-10-25T01:46:02+00:00"
+        },
+        {
+            "name": "phpcompatibility/phpcompatibility-wp",
+            "version": "2.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibilityWP.git",
+                "reference": "b6c1e3ee1c35de6c41a511d5eb9bd03e447480a5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/b6c1e3ee1c35de6c41a511d5eb9bd03e447480a5",
+                "reference": "b6c1e3ee1c35de6c41a511d5eb9bd03e447480a5",
+                "shasum": ""
+            },
+            "require": {
+                "phpcompatibility/php-compatibility": "^9.0",
+                "phpcompatibility/phpcompatibility-paragonie": "^1.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "lead"
+                }
+            ],
+            "description": "A ruleset for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by WordPress.",
+            "homepage": "http://phpcompatibility.com/",
+            "keywords": [
+                "compatibility",
+                "phpcs",
+                "standards",
+                "static analysis",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibilityWP/issues",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibilityWP"
+            },
+            "time": "2022-10-24T09:00:36+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "9.2.30",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "ca2bd87d2f9215904682a9cb9bb37dda98e76089"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/ca2bd87d2f9215904682a9cb9bb37dda98e76089",
+                "reference": "ca2bd87d2f9215904682a9cb9bb37dda98e76089",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-xmlwriter": "*",
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=7.3",
+                "phpunit/php-file-iterator": "^3.0.3",
+                "phpunit/php-text-template": "^2.0.2",
+                "sebastian/code-unit-reverse-lookup": "^2.0.2",
+                "sebastian/complexity": "^2.0",
+                "sebastian/environment": "^5.1.2",
+                "sebastian/lines-of-code": "^1.0.3",
+                "sebastian/version": "^3.0.1",
+                "theseer/tokenizer": "^1.2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-pcov": "PHP extension that provides line coverage",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "9.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.30"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-22T06:47:57+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "3.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-12-02T12:48:52+00:00"
+        },
+        {
+            "name": "phpunit/php-invoker",
+            "version": "3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/3.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:58:55+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T05:33:50+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "5.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:16:10+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "9.6.15",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "05017b80304e0eb3f31d90194a563fd53a6021f1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/05017b80304e0eb3f31d90194a563fd53a6021f1",
+                "reference": "05017b80304e0eb3f31d90194a563fd53a6021f1",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.3.1 || ^2",
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.10.1",
+                "phar-io/manifest": "^2.0.3",
+                "phar-io/version": "^3.0.2",
+                "php": ">=7.3",
+                "phpunit/php-code-coverage": "^9.2.28",
+                "phpunit/php-file-iterator": "^3.0.5",
+                "phpunit/php-invoker": "^3.1.1",
+                "phpunit/php-text-template": "^2.0.3",
+                "phpunit/php-timer": "^5.0.2",
+                "sebastian/cli-parser": "^1.0.1",
+                "sebastian/code-unit": "^1.0.6",
+                "sebastian/comparator": "^4.0.8",
+                "sebastian/diff": "^4.0.3",
+                "sebastian/environment": "^5.1.3",
+                "sebastian/exporter": "^4.0.5",
+                "sebastian/global-state": "^5.0.1",
+                "sebastian/object-enumerator": "^4.0.3",
+                "sebastian/resource-operations": "^3.0.3",
+                "sebastian/type": "^3.2",
+                "sebastian/version": "^3.0.2"
+            },
+            "suggest": {
+                "ext-soap": "To be able to generate mocks based on WSDL files",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "9.6-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Framework/Assert/Functions.php"
+                ],
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.15"
+            },
+            "funding": [
+                {
+                    "url": "https://phpunit.de/sponsors.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-12-01T16:55:19+00:00"
+        },
+        {
+            "name": "sebastian/cli-parser",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/442e7c7e687e42adc03470c7b668bc4b2402c0b2",
+                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for parsing CLI options",
+            "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T06:08:49+00:00"
+        },
+        {
+            "name": "sebastian/code-unit",
+            "version": "1.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit.git",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/code-unit",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/1.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:08:54+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/2.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:30:19+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "4.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "fa0f136dd2334583309d32b62544682ee972b51a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/fa0f136dd2334583309d32b62544682ee972b51a",
+                "reference": "fa0f136dd2334583309d32b62544682ee972b51a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/diff": "^4.0",
+                "sebastian/exporter": "^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-09-14T12:41:17+00:00"
+        },
+        {
+            "name": "sebastian/complexity",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/complexity.git",
+                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/25f207c40d62b8b7aa32f5ab026c53561964053a",
+                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for calculating the complexity of PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/complexity",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/complexity/issues",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-22T06:19:30+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "4.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "74be17022044ebaaecfdf0c5cd504fc9cd5a7131"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/74be17022044ebaaecfdf0c5cd504fc9cd5a7131",
+                "reference": "74be17022044ebaaecfdf0c5cd504fc9cd5a7131",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3",
+                "symfony/process": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-05-07T05:35:17+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "5.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-posix": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:03:51+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "4.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d",
+                "reference": "ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "ext-mbstring": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-09-14T06:03:37+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "5.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "bde739e7565280bda77be70044ac1047bc007e34"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bde739e7565280bda77be70044ac1047bc007e34",
+                "reference": "bde739e7565280bda77be70044ac1047bc007e34",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "ext-dom": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-uopz": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-08-02T09:26:13+00:00"
+        },
+        {
+            "name": "sebastian/lines-of-code",
+            "version": "1.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
+                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/e1e4a170560925c26d424b6a03aed157e7dcc5c5",
+                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for counting the lines of code in PHP source code",
+            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-22T06:20:34+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/5c9eeac41b290a3712d88851518825ad78f45c71",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/4.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:12:34+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:14:26+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "4.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
+                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:07:39+00:00"
+        },
+        {
+            "name": "sebastian/resource-operations",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
+                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/resource-operations/issues",
+                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T06:45:17+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "source": "https://github.com/sebastianbergmann/type/tree/3.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:13:03+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c6c1022351a901512170118436c764e473f6de8c",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "source": "https://github.com/sebastianbergmann/version/tree/3.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T06:39:44+00:00"
+        },
+        {
+            "name": "sirbrillig/phpcs-variable-analysis",
+            "version": "v2.11.17",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sirbrillig/phpcs-variable-analysis.git",
+                "reference": "3b71162a6bf0cde2bff1752e40a1788d8273d049"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/3b71162a6bf0cde2bff1752e40a1788d8273d049",
+                "reference": "3b71162a6bf0cde2bff1752e40a1788d8273d049",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0",
+                "squizlabs/php_codesniffer": "^3.5.6"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || ^1.0",
+                "phpcsstandards/phpcsdevcs": "^1.1",
+                "phpstan/phpstan": "^1.7",
+                "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.5 || ^7.0 || ^8.0 || ^9.0",
+                "sirbrillig/phpcs-import-detection": "^1.1",
+                "vimeo/psalm": "^0.2 || ^0.3 || ^1.1 || ^4.24 || ^5.0@beta"
+            },
+            "type": "phpcodesniffer-standard",
+            "autoload": {
+                "psr-4": {
+                    "VariableAnalysis\\": "VariableAnalysis/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sam Graham",
+                    "email": "php-codesniffer-variableanalysis@illusori.co.uk"
+                },
+                {
+                    "name": "Payton Swick",
+                    "email": "payton@foolord.com"
+                }
+            ],
+            "description": "A PHPCS sniff to detect problems with variables.",
+            "keywords": [
+                "phpcs",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/sirbrillig/phpcs-variable-analysis/issues",
+                "source": "https://github.com/sirbrillig/phpcs-variable-analysis",
+                "wiki": "https://github.com/sirbrillig/phpcs-variable-analysis/wiki"
+            },
+            "time": "2023-08-05T23:46:11+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
+                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/1359e176e9307e906dc3d890bcc9603ff6d90619",
+                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "bin": [
+                "bin/phpcs",
+                "bin/phpcbf"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
+            "keywords": [
+                "phpcs",
+                "standards"
+            ],
+            "support": {
+                "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
+                "source": "https://github.com/squizlabs/PHP_CodeSniffer",
+                "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2022-06-18T07:21:10+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "b2ad5003ca10d4ee50a12da31de12a5774ba6b96"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b2ad5003ca10d4ee50a12da31de12a5774ba6b96",
+                "reference": "b2ad5003ca10d4ee50a12da31de12a5774ba6b96",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/1.2.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-11-20T00:12:19+00:00"
+        },
+        {
+            "name": "wp-coding-standards/wpcs",
+            "version": "2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
+                "reference": "7da1894633f168fe244afc6de00d141f27517b62"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/7da1894633f168fe244afc6de00d141f27517b62",
+                "reference": "7da1894633f168fe244afc6de00d141f27517b62",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.3.1"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6",
+                "phpcompatibility/php-compatibility": "^9.0",
+                "phpcsstandards/phpcsdevtools": "^1.0",
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/WordPress/WordPress-Coding-Standards/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer rules (sniffs) to enforce WordPress coding conventions",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/WordPress/WordPress-Coding-Standards/issues",
+                "source": "https://github.com/WordPress/WordPress-Coding-Standards",
+                "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
+            },
+            "time": "2020-05-13T23:57:56+00:00"
+        },
+        {
+            "name": "yoast/phpunit-polyfills",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
+                "reference": "224e4a1329c03d8bad520e3fc4ec980034a4b212"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/224e4a1329c03d8bad520e3fc4ec980034a4b212",
+                "reference": "224e4a1329c03d8bad520e3fc4ec980034a4b212",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+            },
+            "require-dev": {
+                "yoast/yoastcs": "^2.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "phpunitpolyfills-autoload.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Team Yoast",
+                    "email": "support@yoast.com",
+                    "homepage": "https://yoast.com"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/Yoast/PHPUnit-Polyfills/graphs/contributors"
+                }
+            ],
+            "description": "Set of polyfills for changed PHPUnit functionality to allow for creating PHPUnit cross-version compatible tests",
+            "homepage": "https://github.com/Yoast/PHPUnit-Polyfills",
+            "keywords": [
+                "phpunit",
+                "polyfill",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/Yoast/PHPUnit-Polyfills/issues",
+                "source": "https://github.com/Yoast/PHPUnit-Polyfills"
+            },
+            "time": "2023-08-19T14:25:08+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {
+        "10up/phpcs-composer": 20
+    },
+    "prefer-stable": true,
+    "prefer-lowest": false,
+    "platform": {
+        "php": ">=7.4"
+    },
+    "platform-dev": [],
+    "plugin-api-version": "2.3.0"
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<phpunit
+	bootstrap="./tests/php/bootstrap.php"
+	backupGlobals="false"
+	colors="true"
+	convertErrorsToExceptions="true"
+	convertNoticesToExceptions="true"
+	convertWarningsToExceptions="true"
+	>
+	<testsuites>
+		<testsuite name="archived-post-status-tests">
+			<directory suffix="Test.php">./tests/php/</directory>
+		</testsuite>
+	</testsuites>
+</phpunit>

--- a/readme.md
+++ b/readme.md
@@ -95,13 +95,16 @@ You can modify the label text, the separator, whether it appears before or after
 
 Follow the examples below, adding the code snippet to your theme's `functions.php` file or as an [MU plugin](http://codex.wordpress.org/Must_Use_Plugins).
 
-**Remove the label**
+#### Remove the label
+
 `add_filter( 'aps_title_label', '__return_false' );`
 
-**Place the label _after_ the title**
+#### Place the label _after_ the title
+
 `add_filter( 'aps_title_label_before', '__return_false' );`
 
-**Change the separator**
+#### Change the separator
+
 The separator is the string that separates the "Archived" label and the post title, _including spaces_. When the label appears before the title, the separator is a colon and space `: `, if the label is placed after the title it is a dash with spaces on each side ` - `.
 
 You can customize the separator with the following filter:

--- a/readme.md
+++ b/readme.md
@@ -9,14 +9,13 @@ Allows posts and pages to be archived so you can unpublish content without havin
 
 **Contributors:** [joshuadavidnelson](https://github.com/joshuadavidnelson), [fjarrett](https://profiles.wordpress.org/fjarrett)  
 **Tags:** [admin](https://wordpress.org/plugins/tags/admin), [posts](https://wordpress.org/plugins/tags/posts), [pages](https://wordpress.org/plugins/tags/pages), [status](https://wordpress.org/plugins/tags/status), [workflow](https://wordpress.org/plugins/tags/workflow)  
-**Requires at least:** 5.3  
+**Minimum PHP version supported:** 7.4
+**Minimum WP Version supported:** 5.3  
 **Tested up to:** 6.4.2  
-**Stable tag:** 0.3.8  
+**Stable tag:** 0.3.9  
 **License:** [GPL-2.0](https://www.gnu.org/licenses/gpl-2.0.html)  
 
 ## Description
-
-**Did you find this plugin helpful? Please consider [leaving a 5-star review](https://wordpress.org/support/view/plugin-reviews/archived-post-status).**
 
 This plugin allows you to archive your WordPress content similar to the way you archive your e-mail.
 
@@ -25,22 +24,17 @@ This plugin allows you to archive your WordPress content similar to the way you 
 * Compatible with posts, pages and custom post types
 * Ideal for sites where certain kinds of content is not meant to be evergreen
 
-**Languages supported:**
+**[Over 13](https://translate.wordpress.org/projects/wp-plugins/archived-post-status/)** languages supported
 
-* English
-* Čeština
-* Deutsch
-* Español
-* Français
-* Nederlands
-* Português
-* Русский
+**Pull requests welcome, please follow [these guidelines](/code-of-conduct.md).**
 
-**Development of this plugin is done [on GitHub](https://github.com/fjarrett/archived-post-status). Pull requests welcome. Please see [issues reported](https://github.com/fjarrett/archived-post-status/issues) there before going to the plugin forum.**
+**Please see [issues reported](https://github.com/joshuadavidnelson/archived-post-status/issues) there before going to the plugin forum.**
+
+**Did you find this plugin helpful? Please consider [leaving a 5-star review](https://wordpress.org/support/view/plugin-reviews/archived-post-status).**
 
 ## Frequently Asked Questions
 
-## Isn't this the same as using the Draft or Private statuses?
+### Isn't this the same as using the Draft or Private statuses?
 
 Actually, no, they are not the same thing.
 
@@ -52,7 +46,7 @@ The Archived post status, on the other hand, is meant to be a "post-published" s
 
 Of course, you can always change the status back to Draft or Publish if you want to be able to edit its content again.
 
-## Can't I just trash old content I don't want anymore?
+### Can't I just trash old content I don't want anymore?
 
 Yes, there is nothing wong with trashing old content. And the behavior of the Archived status is very similar to that of trashing.
 

--- a/readme.md
+++ b/readme.md
@@ -5,6 +5,8 @@
 
 [![WordPress Plugin Version](https://img.shields.io/wordpress/plugin/v/archived-post-status)](https://wordpress.org/plugins/archived-post-status/) ![Downloads](https://img.shields.io/wordpress/plugin/dt/archived-post-status.svg) ![Rating](https://img.shields.io/wordpress/plugin/r/archived-post-status.svg)
 
+[![WP compatibility](https://plugintests.com/plugins/wporg/archived-post-status/wp-badge.svg)](https://plugintests.com/plugins/wporg/archived-post-status/latest) [![PHP compatibility](https://plugintests.com/plugins/wporg/archived-post-status/php-badge.svg)](https://plugintests.com/plugins/wporg/archived-post-status/latest)
+
 Allows posts and pages to be archived so you can unpublish content without having to trash it.
 
 **Contributors:** [joshuadavidnelson](https://github.com/joshuadavidnelson), [fjarrett](https://profiles.wordpress.org/fjarrett)  
@@ -19,10 +21,12 @@ Allows posts and pages to be archived so you can unpublish content without havin
 
 This plugin allows you to archive your WordPress content similar to the way you archive your e-mail.
 
-* Makes a new post status available in the dropdown called Archived
 * Unpublish your posts and pages without having to trash them
-* Compatible with posts, pages and custom post types
+* Archives content, making it hidden from public view 
+* Compatible with posts, pages and call public ustom post types
 * Ideal for sites where certain kinds of content is not meant to be evergreen
+* Easily extended (see walkthroughs below)
+
 
 **[Over 13](https://translate.wordpress.org/projects/wp-plugins/archived-post-status/)** languages supported
 
@@ -50,7 +54,7 @@ Of course, you can always change the status back to Draft or Publish if you want
 
 Yes, there is nothing wong with trashing old content. And the behavior of the Archived status is very similar to that of trashing.
 
-However, WordPress automatically purges trashed posts every 7 days (by [default]()).
+However, WordPress permanently deletes trashed posts after 30 days ([see here](https://codex.wordpress.org/Trash_status#Default_Days_before_Permanently_Deleted)).
 
 This is what makes the Archived post status handy. You can unpublish content without having to delete it forever.
 
@@ -74,9 +78,18 @@ function my_aps_default_read_capability( $capability ) {
 add_filter( 'aps_default_read_capability', 'my_aps_default_read_capability' );
 ```
 
+### Can I make Archived posts appear on the front-end for all users?
+Yes, add these hooks to your theme's `functions.php` file or as an [MU plugin](http://codex.wordpress.org/Must_Use_Plugins):
+
+```php
+add_filter( 'aps_status_arg_public', '__return_true' );
+add_filter( 'aps_status_arg_private', '__return_false' );
+add_filter( 'aps_status_arg_exclude_from_search', '__return_false' );
+```
+
 ### Can I change the status name?
 
-You can change the "Archived" string used for the custom status name by adding the code snippet to your theme's `functions.php` file or as an [MU plugin](http://codex.wordpress.org/Must_Use_Plugins):
+You can change the post status name, the "Archived" string, by adding the code snippet to your theme's `functions.php` file or as an [MU plugin](http://codex.wordpress.org/Must_Use_Plugins):
 
 ```
 add_filter( 'aps_archived_label_string', function( $label ) {
@@ -85,13 +98,13 @@ add_filter( 'aps_archived_label_string', function( $label ) {
 });
 ```
 
-This will change the label used on the admin and on the post title label (see below).
+This will change the name used in the admin and on the post title label (see below).
 
 ### How to modify or disable the "Archived" label added to the post title
 
 This plugin automatically adds `Archived:` to the title of archived content. (Note that archived content is only viewable to logged in users with the [`read_private_posts`](http://codex.wordpress.org/Roles_and_Capabilities#read_private_posts) capability).
 
-You can modify the label text, the separator, whether it appears before or after the title, or completely disable it. 
+You can modify the label text, the separator, whether it appears before or after the title, or disable it entirely. 
 
 Follow the examples below, adding the code snippet to your theme's `functions.php` file or as an [MU plugin](http://codex.wordpress.org/Must_Use_Plugins).
 
@@ -105,7 +118,7 @@ Follow the examples below, adding the code snippet to your theme's `functions.ph
 
 #### Change the separator
 
-The separator is the string that separates the "Archived" label and the post title, _including spaces_. When the label appears before the title, the separator is a colon and space `: `, if the label is placed after the title it is a dash with spaces on each side ` - `.
+The separator is the string between the "Archived" label and the post title, _including spaces_. When the label appears before the title, the separator is a colon and space `: `, if the label is placed after the title it is a dash with spaces on each side ` - `.
 
 You can customize the separator with the following filter:
 ```
@@ -115,17 +128,9 @@ add_filter( 'aps_title_separator', function( $sep ) {
 });
 ```
 
-### Can I make Archived posts appear on the front-end for all users?
-Yes, simply add these hooks to your theme's `functions.php` file or as an [MU plugin](http://codex.wordpress.org/Must_Use_Plugins):
-
-```php
-add_filter( 'aps_status_arg_public', '__return_true' );
-add_filter( 'aps_status_arg_private', '__return_false' );
-add_filter( 'aps_status_arg_exclude_from_search', '__return_false' );
-```
-
 ### Can I make Archived posts hidden from the "All" list in the WP Admin, similar to Trashed posts?
-Yes, simply add these hooks to your theme's `functions.php` file or as an [MU plugin](http://codex.wordpress.org/Must_Use_Plugins):
+
+Add these hooks to your theme's `functions.php` file or as an [MU plugin](http://codex.wordpress.org/Must_Use_Plugins):
 
 ```php
 add_filter( 'aps_status_arg_public', '__return_false' );
@@ -133,10 +138,11 @@ add_filter( 'aps_status_arg_private', '__return_false' );
 add_filter( 'aps_status_arg_show_in_admin_all_list', '__return_false' );
 ```
 
-Please note that there is a [bug in core](https://core.trac.wordpress.org/ticket/24415) that requires public and private to be set to false in order for the `aps_status_arg_show_in_admin_all_list` to also be false. There are many bugs in core surrounding registering custom post statuses, so if something doesn't work the way you want on the first try be prepared to do some digging through trac :-)
+Please note that there is a [bug in core](https://core.trac.wordpress.org/ticket/24415) that requires public and private to be set to false in order for the `aps_status_arg_show_in_admin_all_list` to also be false. 
 
 ### Can I exclude the Archived status from appearing on certain post types?
-Yes, simply add this hook to your theme's `functions.php` file or as an [MU plugin](http://codex.wordpress.org/Must_Use_Plugins):
+
+Add this hook to your theme's `functions.php` file or as an [MU plugin](http://codex.wordpress.org/Must_Use_Plugins):
 
 ```php
 function my_aps_excluded_post_types( $post_types ) {
@@ -149,13 +155,13 @@ add_filter( 'aps_excluded_post_types', 'my_aps_excluded_post_types' );
 
 ### My archived posts have disappeared when I deactivate the plugin!
 
-Don't worry, your content is not __gone__ it's just __inaccessible__. Unfortunately, using a custom post status like `archive` is only going to work while the plugin is active.
+Don't worry, your content is _not_ gone it's just __inaccessible__. Unfortunately, using a custom post status like `archive` is only going to work while the plugin is active.
 
-If you have archived content and deativate or delete this plugin, that content will disappear from __view__. You're content is in the database - WordPress just no longer recognizes the `post_status` because this plugin is not there to set this post status up. 
+If you have archived content and deactivate or delete this plugin, that content will disappear from _view_. Your content is in the database - WordPress just no longer recognizes the `post_status` because this plugin is not there to set this post status up. 
 
 If you no longer need the plugin but want to retain your archived content:
-1. (Re)activate this plugin
-2. Switch all the archived posts/pages/cpts to a native post status, like 'draft' or 'publish'
+1. Activate this plugin
+2. Switch all the archived posts/pages/post types to a native post status, like 'draft' or 'publish'
 3. THEN deactivate/delete the plugin.
 
 

--- a/readme.md
+++ b/readme.md
@@ -62,7 +62,7 @@ This is what makes the Archived post status handy. You can unpublish content wit
 
 ### Where are the options for this plugin?
 
-This plugin does not have a settings page. However, there are numerous hooks available in the plugin so you can customize default behaviors. Many of those hooks are listed below in this FAQ
+This plugin does not have a settings page. However, there are numerous hooks available in the plugin so you can customize default behaviors. Many of those hooks are listed below in this FAQ.
 
 ### Why are Archived posts appearing on the front-end?
 This is most likely because you are viewing your site while being logged in as an Editor or Administrator.
@@ -111,6 +111,17 @@ function my_aps_excluded_post_types( $post_types ) {
 }
 add_filter( 'aps_excluded_post_types', 'my_aps_excluded_post_types' );
 ```
+
+### My archived posts have disappeared when I deactivate the plugin!
+
+Don't worry, your content is not __gone__ it's just __inaccessible__. Unfortunately, using a custom post status like `archive` is only going to work while the plugin is active.
+
+If you have archived content and deativate or delete this plugin, that content will disappear from __view__. You're content is in the database - WordPress just no longer recognizes the `post_status` because this plugin is not there to set this post status up. 
+
+If you no longer need the plugin but want to retain your archived content:
+1. (Re)activate this plugin
+2. Switch all the archived posts/pages/cpts to a native post status, like 'draft' or 'publish'
+3. THEN deactivate/delete the plugin.
 
 
 ## Screenshots

--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,7 @@ Allows posts and pages to be archived so you can unpublish content without havin
 **Stable tag:** 0.3.8  
 **License:** [GPL-2.0](https://www.gnu.org/licenses/gpl-2.0.html)  
 
-## Description ##
+## Description
 
 **Did you find this plugin helpful? Please consider [leaving a 5-star review](https://wordpress.org/support/view/plugin-reviews/archived-post-status).**
 
@@ -38,12 +38,33 @@ This plugin allows you to archive your WordPress content similar to the way you 
 
 **Development of this plugin is done [on GitHub](https://github.com/fjarrett/archived-post-status). Pull requests welcome. Please see [issues reported](https://github.com/fjarrett/archived-post-status/issues) there before going to the plugin forum.**
 
-## Frequently Asked Questions ##
+## Frequently Asked Questions
 
-### Where are the options for this plugin? ###
-This plugin does not have a settings page. However, there are numerous hooks available in the plugin so you can customize default behaviors. Many of those hooks are listed below in this FAQ.
+## Isn't this the same as using the Draft or Private statuses?
 
-### Why are Archived posts appearing on the front-end? ###
+Actually, no, they are not the same thing.
+
+The Draft status is a "pre-published" status that is reserved for content that is still being worked on. You can still make changes to content marked as Draft, and you can preview your changes.
+
+The Private status is a special kind of published status. It means the content is published, but only certain logged-in users can view it.
+
+The Archived post status, on the other hand, is meant to be a "post-published" status. Once a post has been set to Archived it can no longer be edited or viewed.
+
+Of course, you can always change the status back to Draft or Publish if you want to be able to edit its content again.
+
+## Can't I just trash old content I don't want anymore?
+
+Yes, there is nothing wong with trashing old content. And the behavior of the Archived status is very similar to that of trashing.
+
+However, WordPress automatically purges trashed posts every 7 days (by [default]()).
+
+This is what makes the Archived post status handy. You can unpublish content without having to delete it forever.
+
+### Where are the options for this plugin?
+
+This plugin does not have a settings page. However, there are numerous hooks available in the plugin so you can customize default behaviors. Many of those hooks are listed below in this FAQ
+
+### Why are Archived posts appearing on the front-end?
 This is most likely because you are viewing your site while being logged in as an Editor or Administrator.
 
 By default, any user with the [`read_private_posts`](http://codex.wordpress.org/Roles_and_Capabilities#read_private_posts) capability will see Archived posts appear on the front-end of your site.
@@ -59,7 +80,7 @@ function my_aps_default_read_capability( $capability ) {
 add_filter( 'aps_default_read_capability', 'my_aps_default_read_capability' );
 ```
 
-### Can I make Archived posts appear on the front-end for all users? ###
+### Can I make Archived posts appear on the front-end for all users?
 Yes, simply add these hooks to your theme's `functions.php` file or as an [MU plugin](http://codex.wordpress.org/Must_Use_Plugins):
 
 ```php
@@ -68,7 +89,7 @@ add_filter( 'aps_status_arg_private', '__return_false' );
 add_filter( 'aps_status_arg_exclude_from_search', '__return_false' );
 ```
 
-### Can I make Archived posts hidden from the "All" list in the WP Admin, similar to Trashed posts? ###
+### Can I make Archived posts hidden from the "All" list in the WP Admin, similar to Trashed posts?
 Yes, simply add these hooks to your theme's `functions.php` file or as an [MU plugin](http://codex.wordpress.org/Must_Use_Plugins):
 
 ```php
@@ -79,7 +100,7 @@ add_filter( 'aps_status_arg_show_in_admin_all_list', '__return_false' );
 
 Please note that there is a [bug in core](https://core.trac.wordpress.org/ticket/24415) that requires public and private to be set to false in order for the `aps_status_arg_show_in_admin_all_list` to also be false. There are many bugs in core surrounding registering custom post statuses, so if something doesn't work the way you want on the first try be prepared to do some digging through trac :-)
 
-### Can I exclude the Archived status from appearing on certain post types? ###
+### Can I exclude the Archived status from appearing on certain post types?
 Yes, simply add this hook to your theme's `functions.php` file or as an [MU plugin](http://codex.wordpress.org/Must_Use_Plugins):
 
 ```php
@@ -91,26 +112,8 @@ function my_aps_excluded_post_types( $post_types ) {
 add_filter( 'aps_excluded_post_types', 'my_aps_excluded_post_types' );
 ```
 
-### Isn't this the same as using the Draft or Private statuses? ###
-Actually, no, they are not the same thing.
 
-The Draft status is a "pre-published" status that is reserved for content that is still being worked on. You can still make changes to content marked as Draft, and you can preview your changes.
-
-The Private status is a special kind of published status. It means the content is published, but only certain logged-in users can view it.
-
-The Archived post status, on the other hand, is meant to be a "post-published" status. Once a post has been set to Archived it can no longer be edited or viewed.
-
-Of course, you can always change the status back to Draft or Publish if you want to be able to edit its content again.
-
-### Can't I just trash old content I don't want anymore? ###
-Yes, there is nothing wong with trashing old content. And the behavior of the Archived status is very similar to that of trashing.
-
-However, WordPress automatically purges trashed posts every 7 days (by default).
-
-This is what makes the Archived post status handy. You can unpublish content without having to delete it forever.
-
-
-## Screenshots ##
+## Screenshots
 
 ### Post list table screen.
 

--- a/readme.md
+++ b/readme.md
@@ -21,11 +21,10 @@ Allows posts and pages to be archived so you can unpublish content without havin
 This plugin allows you to archive your WordPress content similar to the way you archive your e-mail.
 
 * Unpublish your posts and pages without having to trash them
-* Archives content, making it hidden from public view 
-* Compatible with posts, pages and call public ustom post types
+* Archive content is hidden from public view 
+* Compatible with posts, pages, and public custom post types
 * Ideal for sites where certain kinds of content is not meant to be evergreen
-* Easily extended (see walkthroughs below)
-
+* Easily extended (see below)
 
 **[Over 13](https://translate.wordpress.org/projects/wp-plugins/archived-post-status/)** languages supported
 

--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,6 @@
 Allows posts and pages to be archived so you can unpublish content without having to trash it.
 
 **Contributors:** [joshuadavidnelson](https://github.com/joshuadavidnelson), [fjarrett](https://profiles.wordpress.org/fjarrett)  
-**Tags:** [admin](https://wordpress.org/plugins/tags/admin), [posts](https://wordpress.org/plugins/tags/posts), [pages](https://wordpress.org/plugins/tags/pages), [status](https://wordpress.org/plugins/tags/status), [workflow](https://wordpress.org/plugins/tags/workflow)  
 **Minimum PHP version supported:** 7.4
 **Minimum WP Version supported:** 5.3  
 **Tested up to:** 6.4.2  

--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@
 Allows posts and pages to be archived so you can unpublish content without having to trash it.
 
 **Contributors:** [joshuadavidnelson](https://github.com/joshuadavidnelson), [fjarrett](https://profiles.wordpress.org/fjarrett)  
-**Minimum PHP version supported:** 7.4
+**Minimum PHP version supported:** 7.4  
 **Minimum WP Version supported:** 5.3  
 **Tested up to:** 6.4.2  
 **Stable tag:** 0.3.9  

--- a/readme.md
+++ b/readme.md
@@ -74,6 +74,44 @@ function my_aps_default_read_capability( $capability ) {
 add_filter( 'aps_default_read_capability', 'my_aps_default_read_capability' );
 ```
 
+### Can I change the status name?
+
+You can change the "Archived" string used for the custom status name by adding the code snippet to your theme's `functions.php` file or as an [MU plugin](http://codex.wordpress.org/Must_Use_Plugins):
+
+```
+add_filter( 'aps_archived_label_string', function( $label ) {
+	$label = 'Custom Label'; // replace with your custom label
+	return $label;
+});
+```
+
+This will change the label used on the admin and on the post title label (see below).
+
+### How to modify or disable the "Archived" label added to the post title
+
+This plugin automatically adds `Archived:` to the title of archived content. (Note that archived content is only viewable to logged in users with the [`read_private_posts`](http://codex.wordpress.org/Roles_and_Capabilities#read_private_posts) capability).
+
+You can modify the label text, the separator, whether it appears before or after the title, or completely disable it. 
+
+Follow the examples below, adding the code snippet to your theme's `functions.php` file or as an [MU plugin](http://codex.wordpress.org/Must_Use_Plugins).
+
+**Remove the label**
+`add_filter( 'aps_title_label', '__return_false' );`
+
+**Place the label _after_ the title**
+`add_filter( 'aps_title_label_before', '__return_false' );`
+
+**Change the separator**
+The separator is the string that separates the "Archived" label and the post title, _including spaces_. When the label appears before the title, the separator is a colon and space `: `, if the label is placed after the title it is a dash with spaces on each side ` - `.
+
+You can customize the separator with the following filter:
+```
+add_filter( 'aps_title_separator', function( $sep ) {
+	$sep = ' ~ '; // replace with your separator
+	return $sep;
+});
+```
+
 ### Can I make Archived posts appear on the front-end for all users?
 Yes, simply add these hooks to your theme's `functions.php` file or as an [MU plugin](http://codex.wordpress.org/Must_Use_Plugins):
 

--- a/readme.txt
+++ b/readme.txt
@@ -15,10 +15,10 @@ Use an "Archived" status to unpublish content without having to trash it.
 This plugin allows you to archive your WordPress content similar to the way you archive your e-mail.
 
 * Unpublish your posts and pages without having to trash them
-* Archives content, making it hidden from public view
-* Compatible with posts, pages and call public ustom post types
+* Archive content is hidden from public view
+* Compatible with posts, pages, and public custom post types
 * Ideal for sites where certain kinds of content is not meant to be evergreen
-* Easily extended (see walkthroughs below)
+* Easily extended (see below)
 
 **[Over 13](https://translate.wordpress.org/projects/wp-plugins/archived-post-status/)** languages supported
 

--- a/readme.txt
+++ b/readme.txt
@@ -101,6 +101,17 @@ function my_aps_excluded_post_types( $post_types ) {
 add_filter( 'aps_excluded_post_types', 'my_aps_excluded_post_types' );
 </pre>
 
+= My archived posts have disappeared when I deactivate the plugin! =
+
+Don't worry, your content is not __gone__ it's just __inaccessible__. Unfortunately, using a custom post status like `archive` is only going to work while the plugin is active.
+
+If you have archived content and deativate or delete this plugin, that content will disappear from __view__. You're content is in the database - WordPress just no longer recognizes the `post_status` because this plugin is not there to set this post status up.
+
+If you no longer need the plugin but want to retain your archived content:
+1. (Re)activate this plugin
+2. Switch all the archived posts/pages/cpts to a native post status, like 'draft' or 'publish'
+3. Then deactivate/delete the plugin.
+
 = Help! I need support =
 
 Please reach out on the Github Issues or in the WordPress support forums.
@@ -116,6 +127,14 @@ Please reach out on the Github Issues or in the WordPress support forums.
 3. Publish metabox controls.
 
 == Changelog ==
+
+= 0.3.9 =
+- Fix deprecated php warning on `filter_input`, using native WP functions for escaping & getting query var.
+- Add `aps_archived_label_string` filter to modify the "Archived" string used for the label.
+- Add `aps_title_separator` and `aps_title_label` to filter the post title prefix and separator, defaults to 'Archived' with a `:` separator. Disable the title prefix entirely by using `add_filter( 'aps_title_prefix', '__return_false' );` in your functions.php file or custom plugin file. Closes #21
+- Added `aps_title_label_before` filter, defaults to `true` - pass `false` to have the label appear after the title instead of before it. This change along with the label string filter above closes #31
+- Add PHPUnit tests & github actions.
+- Update some comments and documentation, readmes, etc
 
 = 0.3.8 - December 15, 2023 =
 
@@ -195,3 +214,18 @@ Props [fjarrett](https://github.com/fjarrett), [pollyplummer](https://github.com
 * Initial release.
 
 Props [fjarrett](https://github.com/fjarrett)
+
+== Upgrade Notice ==
+
+= 0.3.9 =
+
+- Fix deprecated php warning on `filter_input`.
+- Add filters for label and title string & separator, see changelog.
+
+= 0.3.8 =
+
+- Tested up to WordPress 6.4.2
+- Add minimum PHP of 7.4
+- Bump minimum WordPress to 5.3
+- Add Github actions for deployment & coding standards
+- Update contributors in readmes

--- a/readme.txt
+++ b/readme.txt
@@ -19,6 +19,8 @@ This plugin allows you to archive your WordPress content similar to the way you 
 * Compatible with posts, pages, and custom post types
 * Ideal for sites where certain kinds of content is not meant to be evergreen
 
+**[Over 13](https://translate.wordpress.org/projects/wp-plugins/archived-post-status/)** languages supported
+
 **Did you find this plugin helpful? Please consider [leaving a 5-star review](https://wordpress.org/support/view/plugin-reviews/archived-post-status).**
 
 **Development of this plugin is done [on GitHub](https://github.com/joshuadavidnelson/archived-post-status). Pull requests welcome. Please see [issues reported](https://github.com/joshuadavidnelson/archived-post-status/issues) there before going to the plugin forum.**

--- a/readme.txt
+++ b/readme.txt
@@ -78,6 +78,44 @@ add_filter( 'aps_status_arg_private', '__return_false' );
 add_filter( 'aps_status_arg_exclude_from_search', '__return_false' );
 </pre>
 
+= Can I change the status name? =
+
+You can change the "Archived" string used for the custom status name by adding the code snippet to your theme's `functions.php` file or as an [MU plugin](http://codex.wordpress.org/Must_Use_Plugins):
+
+```
+add_filter( 'aps_archived_label_string', function( $label ) {
+	$label = 'Custom Label'; // replace with your custom label
+	return $label;
+});
+```
+
+This will change the label used on the admin and on the post title label (see below).
+
+= How to modify or disable the "Archived" label added to the post title =
+
+This plugin automatically adds `Archived:` to the title of archived content. (Note that archived content is only viewable to logged in users with the [`read_private_posts`](http://codex.wordpress.org/Roles_and_Capabilities#read_private_posts) capability).
+
+You can modify the label text, the separator, whether it appears before or after the title, or completely disable it.
+
+Follow the examples below, adding the code snippet to your theme's `functions.php` file or as an [MU plugin](http://codex.wordpress.org/Must_Use_Plugins).
+
+**Remove the label**
+`add_filter( 'aps_title_label', '__return_false' );`
+
+**Place the label _after_ the title**
+`add_filter( 'aps_title_label_before', '__return_false' );`
+
+**Change the separator**
+The separator is the string that separates the "Archived" label and the post title, _including spaces_. When the label appears before the title, the separator is a colon and space `: `, if the label is placed after the title it is a dash with spaces on each side ` - `.
+
+You can customize the separator with the following filter:
+```
+add_filter( 'aps_title_separator', function( $sep ) {
+	$sep = ' ~ '; // replace with your separator
+	return $sep;
+});
+```
+
 = Can I make Archived posts hidden from the "All" list in the WP Admin, similar to Trashed posts? =
 
 Add these hooks to your theme's `functions.php` file or as an [MU plugin](http://codex.wordpress.org/Must_Use_Plugins):

--- a/readme.txt
+++ b/readme.txt
@@ -131,7 +131,7 @@ Please reach out on the Github Issues or in the WordPress support forums.
 = 0.3.9 =
 - Fix deprecated php warning on `filter_input`, using native WP functions for escaping & getting query var.
 - Add `aps_archived_label_string` filter to modify the "Archived" string used for the label.
-- Add `aps_title_separator` and `aps_title_label` to filter the post title prefix and separator, defaults to 'Archived' with a `:` separator. Disable the title prefix entirely by using `add_filter( 'aps_title_prefix', '__return_false' );` in your functions.php file or custom plugin file. Closes #21
+- Add `aps_title_separator` and `aps_title_label` to filter the post title prefix and separator, defaults to 'Archived' with a `:` separator. Disable the title label entirely by using `add_filter( 'aps_title_prefix', '__return_false' );` in your `functions.php` file or custom plugin file. Closes #21
 - Added `aps_title_label_before` filter, defaults to `true` - pass `false` to have the label appear after the title instead of before it. This change along with the label string filter above closes #31
 - Add PHPUnit tests & github actions.
 - Update some comments and documentation, readmes, etc

--- a/readme.txt
+++ b/readme.txt
@@ -25,6 +25,26 @@ This plugin allows you to archive your WordPress content similar to the way you 
 
 == Frequently Asked Questions ==
 
+= Isn't this the same as using the Draft or Private statuses? =
+
+Actually, no, they are not the same thing.
+
+The Draft status is a "pre-published" status that is reserved for content that is still being worked on. You can still make changes to content marked as Draft, and you can preview your changes.
+
+The Private status is a special kind of published status. It means the content is published, but only certain logged-in users can view it.
+
+The Archived post status, on the other hand, is meant to be a "post-published" status. Once a post has been set to Archived it can no longer be edited or viewed.
+
+Of course, you can always change the status back to Draft or Publish if you want to be able to edit its content again.
+
+= Can't I just trash old content I don't want anymore? =
+
+Yes, there is nothing wong with trashing old content. And the behavior of the Archived status is very similar to that of trashing.
+
+However, WordPress automatically purges trashed posts every 7 days (by default).
+
+This is what makes the Archived post status handy. You can unpublish content without having to delete it forever.
+
 = Where are the options for this plugin? =
 
 This plugin does not have a settings page. However, there are numerous hooks available in the plugin so you can customize default behaviors. Many of those hooks are listed below in this FAQ.
@@ -81,25 +101,13 @@ function my_aps_excluded_post_types( $post_types ) {
 add_filter( 'aps_excluded_post_types', 'my_aps_excluded_post_types' );
 </pre>
 
-= Isn't this the same as using the Draft or Private statuses? =
+= Help! I need support =
 
-They are not the same thing.
+Please reach out on the Github Issues or in the WordPress support forums.
 
-The Draft status is a "pre-published" status that is reserved for content that is still being worked on. You can still make changes to content marked as Draft, and you can preview your changes.
+= I have a feature request =
 
-The Private status is a special kind of published status. It means the content is published, but only certain logged-in users can view it.
-
-The Archived post status, on the other hand, is meant to be a "post-published" status. Once a post has been set to Archived it can no longer be edited or viewed.
-
-Of course, you can always change the status back to Draft or Publish if you want to be able to edit its content again.
-
-= Can't I just trash old content I don't want anymore? =
-
-Yes, there is nothing wong with trashing old content. And the behavior of the Archived status is very similar to that of trashing.
-
-However, WordPress automatically purges trashed posts every 7 days (by default).
-
-This is what makes the Archived post status handy. You can unpublish content without having to delete it forever.
+Please reach out on the Github Issues or in the WordPress support forums.
 
 == Screenshots ==
 

--- a/readme.txt
+++ b/readme.txt
@@ -131,7 +131,7 @@ Please reach out on the Github Issues or in the WordPress support forums.
 == Changelog ==
 
 = 0.3.9 =
-- Fix deprecated php warning on `filter_input`, using native WP functions for escaping & getting query var.
+- Fix deprecated php warning on `filter_input`, using native WP functions for escaping & getting query var. Fixes another issue, where archived posts couldn't be trashed (Closes #35)
 - Add `aps_archived_label_string` filter to modify the "Archived" string used for the label.
 - Add `aps_title_separator` and `aps_title_label` to filter the post title prefix and separator, defaults to 'Archived' with a `:` separator. Disable the title label entirely by using `add_filter( 'aps_title_prefix', '__return_false' );` in your `functions.php` file or custom plugin file. Closes #21
 - Added `aps_title_label_before` filter, defaults to `true` - pass `false` to have the label appear after the title instead of before it. This change along with the label string filter above closes #31

--- a/readme.txt
+++ b/readme.txt
@@ -100,12 +100,15 @@ You can modify the label text, the separator, whether it appears before or after
 Follow the examples below, adding the code snippet to your theme's `functions.php` file or as an [MU plugin](http://codex.wordpress.org/Must_Use_Plugins).
 
 **Remove the label**
+
 `add_filter( 'aps_title_label', '__return_false' );`
 
 **Place the label _after_ the title**
+
 `add_filter( 'aps_title_label_before', '__return_false' );`
 
 **Change the separator**
+
 The separator is the string that separates the "Archived" label and the post title, _including spaces_. When the label appears before the title, the separator is a colon and space `: `, if the label is placed after the title it is a dash with spaces on each side ` - `.
 
 You can customize the separator with the following filter:

--- a/readme.txt
+++ b/readme.txt
@@ -14,9 +14,9 @@ Use an "Archived" status to unpublish content without having to trash it.
 
 This plugin allows you to archive your WordPress content similar to the way you archive your e-mail.
 
-* Makes a new post status available in the dropdown called Archived
+* Makes a new post status available in the dropdown called "Archived"
 * Unpublish your posts and pages without having to trash them
-* Compatible with posts, pages and custom post types
+* Compatible with posts, pages, and custom post types
 * Ideal for sites where certain kinds of content is not meant to be evergreen
 
 **Did you find this plugin helpful? Please consider [leaving a 5-star review](https://wordpress.org/support/view/plugin-reviews/archived-post-status).**

--- a/readme.txt
+++ b/readme.txt
@@ -14,10 +14,11 @@ Use an "Archived" status to unpublish content without having to trash it.
 
 This plugin allows you to archive your WordPress content similar to the way you archive your e-mail.
 
-* Makes a new post status available in the dropdown called "Archived"
 * Unpublish your posts and pages without having to trash them
-* Compatible with posts, pages, and custom post types
+* Archives content, making it hidden from public view
+* Compatible with posts, pages and call public ustom post types
 * Ideal for sites where certain kinds of content is not meant to be evergreen
+* Easily extended (see walkthroughs below)
 
 **[Over 13](https://translate.wordpress.org/projects/wp-plugins/archived-post-status/)** languages supported
 
@@ -43,7 +44,7 @@ Of course, you can always change the status back to Draft or Publish if you want
 
 Yes, there is nothing wong with trashing old content. And the behavior of the Archived status is very similar to that of trashing.
 
-However, WordPress automatically purges trashed posts every 7 days (by default).
+However, WordPress permanently deletes trashed posts after 30 days ([see here](https://codex.wordpress.org/Trash_status#Default_Days_before_Permanently_Deleted)).
 
 This is what makes the Archived post status handy. You can unpublish content without having to delete it forever.
 
@@ -80,7 +81,7 @@ add_filter( 'aps_status_arg_exclude_from_search', '__return_false' );
 
 = Can I change the status name? =
 
-You can change the "Archived" string used for the custom status name by adding the code snippet to your theme's `functions.php` file or as an [MU plugin](http://codex.wordpress.org/Must_Use_Plugins):
+You can change the post status name, the "Archived" string, by adding the code snippet to your theme's `functions.php` file or as an [MU plugin](http://codex.wordpress.org/Must_Use_Plugins):
 
 ```
 add_filter( 'aps_archived_label_string', function( $label ) {
@@ -89,13 +90,13 @@ add_filter( 'aps_archived_label_string', function( $label ) {
 });
 ```
 
-This will change the label used on the admin and on the post title label (see below).
+This will change the name used in the admin and on the post title label (see below).
 
 = How to modify or disable the "Archived" label added to the post title =
 
 This plugin automatically adds `Archived:` to the title of archived content. (Note that archived content is only viewable to logged in users with the [`read_private_posts`](http://codex.wordpress.org/Roles_and_Capabilities#read_private_posts) capability).
 
-You can modify the label text, the separator, whether it appears before or after the title, or completely disable it.
+You can modify the label text, the separator, whether it appears before or after the title, or disable it entirely.
 
 Follow the examples below, adding the code snippet to your theme's `functions.php` file or as an [MU plugin](http://codex.wordpress.org/Must_Use_Plugins).
 
@@ -109,7 +110,7 @@ Follow the examples below, adding the code snippet to your theme's `functions.ph
 
 **Change the separator**
 
-The separator is the string that separates the "Archived" label and the post title, _including spaces_. When the label appears before the title, the separator is a colon and space `: `, if the label is placed after the title it is a dash with spaces on each side ` - `.
+The separator is the string between the "Archived" label and the post title, _including spaces_. When the label appears before the title, the separator is a colon and space `: `, if the label is placed after the title it is a dash with spaces on each side ` - `.
 
 You can customize the separator with the following filter:
 ```
@@ -129,7 +130,7 @@ add_filter( 'aps_status_arg_private', '__return_false' );
 add_filter( 'aps_status_arg_show_in_admin_all_list', '__return_false' );
 </pre>
 
-Please note that there is a [bug in core](https://core.trac.wordpress.org/ticket/24415) that requires public and private to be set to false in order for the `aps_status_arg_show_in_admin_all_list` to also be false. There are many bugs in core surrounding registering custom post statuses, so if something doesn't work the way you want on the first try be prepared to do some digging through trac :-)
+Please note that there is a [bug in core](https://core.trac.wordpress.org/ticket/24415) that requires public and private to be set to false in order for the `aps_status_arg_show_in_admin_all_list` to also be false.
 
 = Can I exclude the Archived status from appearing on certain post types? =
 
@@ -146,22 +147,22 @@ add_filter( 'aps_excluded_post_types', 'my_aps_excluded_post_types' );
 
 = My archived posts have disappeared when I deactivate the plugin! =
 
-Don't worry, your content is not __gone__ it's just __inaccessible__. Unfortunately, using a custom post status like `archive` is only going to work while the plugin is active.
+Don't worry, your content is _not_ gone it's just __inaccessible__. Unfortunately, using a custom post status like `archive` is only going to work while the plugin is active.
 
-If you have archived content and deativate or delete this plugin, that content will disappear from __view__. You're content is in the database - WordPress just no longer recognizes the `post_status` because this plugin is not there to set this post status up.
+If you have archived content and deactivate or delete this plugin, that content will disappear from _view_. Your content is in the database - WordPress just no longer recognizes the `post_status` because this plugin is not there to set this post status up.
 
 If you no longer need the plugin but want to retain your archived content:
-1. (Re)activate this plugin
-2. Switch all the archived posts/pages/cpts to a native post status, like 'draft' or 'publish'
-3. Then deactivate/delete the plugin.
+1. Activate this plugin
+2. Switch all the archived posts/pages/post types to a native post status, like 'draft' or 'publish'
+3. THEN deactivate/delete the plugin.
 
 = Help! I need support =
 
-Please reach out on the Github Issues or in the WordPress support forums.
+Please reach out on the [Github Issues](https://github.com/joshuadavidnelson/archived-post-status/issues) or in the WordPress [support forums](https://wordpress.org/support/plugin/archived-post-status/).
 
 = I have a feature request =
 
-Please reach out on the Github Issues or in the WordPress support forums.
+Please reach out on the [Github Issues](https://github.com/joshuadavidnelson/archived-post-status/issues) or in the WordPress [support forums](https://wordpress.org/support/plugin/archived-post-status/).
 
 == Screenshots ==
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === Archive Content with Archived Post Status ===
 Contributors:      joshuadnelson, fjarrett
-Tags:              admin, posts, pages, status, workflow
+Tags:              archive, archived, post status, archive post, admin, status, workflow
 Requires at least: 5.3
 Requires PHP:      7.4
 Tested up to:      6.4.2

--- a/src/archived-post-status.php
+++ b/src/archived-post-status.php
@@ -67,6 +67,26 @@ function aps_archived_label_string() {
 }
 
 /**
+ * The slug used for the Archived post status.
+ *
+ * @since 0.3.9
+ * @return string
+ */
+function aps_post_status_slug() {
+
+	/**
+	 * Filter the slug used for the Archived post status.
+	 *
+	 * @since 0.3.9
+	 * @param string $slug The slug for the post status.
+	 * @return string
+	 */
+	$slug = (string) apply_filters( 'aps_post_status_slug', 'archive' );
+
+	return empty( esc_attr( $slug ) ) ? 'archive' : esc_attr( $slug );
+}
+
+/**
  * Register a custom post status for Archived.
  *
  * @action init
@@ -85,7 +105,9 @@ function aps_register_archive_post_status() {
 		'label_count'               => _n_noop( 'Archived <span class="count">(%s)</span>', 'Archived <span class="count">(%s)</span>', 'archived-post-status' ),
 	);
 
-	register_post_status( 'archive', $args );
+	$slug = aps_post_status_slug();
+
+	register_post_status( $slug, $args );
 }
 add_action( 'init', 'aps_register_archive_post_status' );
 

--- a/src/archived-post-status.php
+++ b/src/archived-post-status.php
@@ -37,6 +37,27 @@ function aps_i18n_strings() {
 }
 
 /**
+ * Filter the archived string.
+ *
+ * @since 0.3.9
+ * @return string
+ */
+function aps_archived_label_string() {
+
+	// translators: The label used for the status.
+	$label = __( 'Archived', 'archived-post-status' );
+
+	/**
+	 * Filter the label used in the plugin for archived content
+	 *
+	 * @since 0.3.9
+	 * @param string $label The "Archived" label.
+	 * @return string
+	 */
+	return apply_filters( 'aps_archived_label_string', $label );
+}
+
+/**
  * Register a custom post status for Archived.
  *
  * @action init
@@ -45,7 +66,7 @@ function aps_register_archive_post_status() {
 
 	$args = array(
 		// translators: The post status label for Archived posts.
-		'label'                     => __( 'Archived', 'archived-post-status' ),
+		'label'                     => aps_archived_label_string(),
 		'public'                    => (bool) apply_filters( 'aps_status_arg_public', aps_current_user_can_view() ),
 		'private'                   => (bool) apply_filters( 'aps_status_arg_private', true ),
 		'exclude_from_search'       => (bool) apply_filters( 'aps_status_arg_exclude_from_search', ! aps_current_user_can_view() ),
@@ -120,17 +141,53 @@ function aps_the_title( $title, $post_id = null ) {
 
 	$post = get_post( $post_id );
 
-	if (
-		! is_admin()
-		&&
-		isset( $post->post_status )
-		&&
-		'archive' === $post->post_status
-	) {
+	if ( ! is_admin() && isset( $post->post_status )
+			&& 'archive' === $post->post_status ) {
 
-		// translators: The post title prefix for archived posts.
-		$title = sprintf( '%1$s: %2$s', __( 'Archived', 'archived-post-status' ), $title );
+		/**
+		 * Filter the label / title separator.
+		 *
+		 * Defaults to a colon.
+		 *
+		 * @since 0.3.9
+		 * @param string $label_text The label text for archived posts.
+		 * @param int    $post_id    Optionally passed, the post object.
+		 * @param string $title      Optionally passed, the post title.
+		 * @return string
+		 */
+		$sep = apply_filters( 'aps_title_separator', ':', $post_id, $title );
 
+		/**
+		 * Filter the label text for archived posts.
+		 *
+		 * @since 0.3.9
+		 * @param string $label_text The label text for archived posts.
+		 * @param int    $post_id    Optionally passed, the post object.
+		 * @param string $title      Optionally passed, the post title.
+		 * @return string
+		 */
+		$label = apply_filters( 'aps_title_label', aps_archived_label_string(), $post_id, $title );
+
+		/**
+		 * Change the location of the label text.
+		 *
+		 * @since 0.3.9
+		 * @param bool $before True to place the before the title,
+		 *                     false to place it after.
+		 * @return bool
+		 */
+		$before = (bool) apply_filters( 'aps_title_label_before', true );
+
+		// Add label to title.
+		if ( ! empty( $label ) ) {
+			if ( $before ) {
+				$label = esc_attr( $label ) . esc_attr( $sep );
+				$title = sprintf( '%1$s %2$s', $label, $title );
+			} else {
+				$label = esc_attr( $sep ) . esc_attr( $label );
+				$title = sprintf( '%1$s %2$s', $title, $label );
+			}
+		}
 	}
 
 	return $title;

--- a/src/archived-post-status.php
+++ b/src/archived-post-status.php
@@ -147,6 +147,10 @@ function aps_is_read_only() {
  */
 function aps_the_title( $title, $post_id = null ) {
 
+	if ( ! $post_id ) {
+		$post_id = get_the_ID();
+	}
+
 	$post = get_post( $post_id );
 
 	if ( ! is_admin() && isset( $post->post_status )

--- a/src/archived-post-status.php
+++ b/src/archived-post-status.php
@@ -378,9 +378,9 @@ add_action( 'load-post.php', 'aps_load_post_screen' );
 function aps_display_post_states( $post_states, $post ) {
 
 	if ( aps_is_excluded_post_type( $post->post_type )
-			|| 'archive' !== $post->post_status
-			|| 'archive' === get_query_var( 'post_status' ) ) {
-				return $post_states;
+		|| 'archive' !== $post->post_status
+		|| 'archive' === get_query_var( 'post_status' ) ) {
+			return $post_states;
 	}
 
 	return array_merge(
@@ -405,8 +405,8 @@ add_filter( 'display_post_states', 'aps_display_post_states', 10, 2 );
 function aps_save_post( $post_id, $post, $update ) {
 
 	if ( aps_is_excluded_post_type( $post->post_type )
-			|| wp_is_post_revision( $post ) ) {
-				return;
+		|| wp_is_post_revision( $post ) ) {
+			return;
 	}
 
 	if ( 'archive' === $post->post_status ) {

--- a/src/archived-post-status.php
+++ b/src/archived-post-status.php
@@ -165,7 +165,7 @@ function aps_the_title( $title, $post_id = null ) {
 		 * @param string $title      Optionally passed, the post title.
 		 * @return string
 		 */
-		$label = (string) apply_filters( 'aps_title_label', aps_archived_label_string(), $post_id );
+		$label = (string) apply_filters( 'aps_title_label', aps_archived_label_string(), $post_id, $title );
 
 		/**
 		 * Change the location of the label text.

--- a/src/archived-post-status.php
+++ b/src/archived-post-status.php
@@ -198,7 +198,7 @@ function aps_the_title( $title, $post_id = null ) {
 		if ( ! empty( $label ) ) {
 
 			// Sanitize the strings.
-			$safe_strings = array_filter( [ $label, $sep ], 'esc_attr' );
+			$safe_strings = array_filter( array( $label, $sep ), 'esc_attr' );
 
 			// Add the strings to the title.
 			$title = $before ? implode( '', $safe_strings ) . $title : $title . implode( '', array_reverse( $safe_strings ) );

--- a/src/archived-post-status.php
+++ b/src/archived-post-status.php
@@ -5,7 +5,6 @@
  * @link    https://github.com/joshuadavidnelson/archived-post-status
  * @since   0.3.8
  * @package ArchivedPostStatus
- * @author  Joshua Nelson <josh@joshuadnelson.com>
  * @license GPL-2.0+
  */
 

--- a/src/archived-post-status.php
+++ b/src/archived-post-status.php
@@ -404,11 +404,26 @@ add_filter( 'display_post_states', 'aps_display_post_states', 10, 2 );
  */
 function aps_save_post( $post_id, $post, $update ) {
 
-	if ( aps_is_excluded_post_type( $post->post_type )
-		|| wp_is_post_revision( $post ) ) {
+	// Bail out if running an autosave, ajax, cron, or revision.
+	if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+		return;
+	}
+	if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
+		return;
+	}
+	if ( defined( 'DOING_CRON' ) && DOING_CRON ) {
+		return;
+	}
+	if ( wp_is_post_revision( $post_id ) ) {
+		return;
+	}
+
+	// Only posts that we're okay with
+	if ( aps_is_excluded_post_type( $post->post_type ) ) {
 			return;
 	}
 
+	// Only posts that are being Archived.
 	if ( 'archive' === $post->post_status ) {
 
 		// Unhook to prevent infinite loop

--- a/src/archived-post-status.php
+++ b/src/archived-post-status.php
@@ -286,8 +286,8 @@ function aps_load_post_screen() {
 
 	}
 
-	$action  = filter_input( INPUT_GET, 'action', FILTER_SANITIZE_STRING );
-	$message = (int) filter_input( INPUT_GET, 'message', FILTER_SANITIZE_NUMBER_INT );
+	$action  = esc_attr( get_query_var( 'action' ) );
+	$message = absint( get_query_var( 'message' ) );
 
 	// Redirect to list table after saving as Archived
 	if ( 'edit' === $action && 1 === $message ) {

--- a/src/archived-post-status.php
+++ b/src/archived-post-status.php
@@ -203,7 +203,6 @@ function aps_the_title( $title, $post_id = null ) {
 			// Add the strings to the title.
 			$title = $before ? implode( '', $safe_strings ) . $title : $title . implode( '', array_reverse( $safe_strings ) );
 
-			print( $title );
 		}
 	}
 

--- a/src/archived-post-status.php
+++ b/src/archived-post-status.php
@@ -63,7 +63,7 @@ function aps_archived_label_string() {
 	 * @param string $label The "Archived" label.
 	 * @return string
 	 */
-	return apply_filters( 'aps_archived_label_string', $label );
+	return esc_attr( apply_filters( 'aps_archived_label_string', $label ) );
 }
 
 /**
@@ -387,7 +387,7 @@ function aps_display_post_states( $post_states, $post ) {
 		$post_states,
 		array(
 			// translators: The post status label for Archived posts.
-			'archive' => __( 'Archived', 'archived-post-status' ),
+			'archive' => aps_archived_label_string(),
 		)
 	);
 }

--- a/src/archived-post-status.php
+++ b/src/archived-post-status.php
@@ -2,11 +2,21 @@
 /**
  * The file that defines the core plugin functions
  *
- * @link       https://github.com/joshuadavidnelson/archived-post-status
- * @since      0.3.8
- * @package    ArchivedPostStatus
- * @author     Joshua Nelson <josh@joshuadnelson.com>
+ * @link    https://github.com/joshuadavidnelson/archived-post-status
+ * @since   0.3.8
+ * @package ArchivedPostStatus
+ * @author  Joshua Nelson <josh@joshuadnelson.com>
+ * @license GPL-2.0+
  */
+
+/**
+ * Exit if accessed directly, prevent direct access to this file.
+ *
+ * @since 0.3.9
+ */
+if ( ! defined( 'ABSPATH' ) ) {
+	die;
+}
 
 /**
  * Load languages.
@@ -14,7 +24,6 @@
  * @action plugins_loaded
  */
 function aps_i18n() {
-
 	load_plugin_textdomain( 'archived-post-status', false, ARCHIVED_POST_STATUS_LANG_PATH );
 }
 add_action( 'plugins_loaded', 'aps_i18n' );
@@ -88,7 +97,6 @@ add_action( 'init', 'aps_register_archive_post_status' );
  * @return bool
  */
 function aps_is_frontend() {
-
 	return ! is_admin();
 }
 add_filter( 'aps_status_arg_exclude_from_search', 'aps_is_frontend' );
@@ -104,7 +112,7 @@ function aps_current_user_can_view() {
 	 * Default capability to grant ability to view Archived content.
 	 *
 	 * @since 0.3.0
-	 *
+	 * @param string $capability The user capability to view archived content.
 	 * @return string
 	 */
 	$capability = (string) apply_filters( 'aps_default_read_capability', 'read_private_posts' );
@@ -123,7 +131,7 @@ function aps_is_read_only() {
 	 * Archived content is read-only by default.
 	 *
 	 * @since 0.3.5
-	 *
+	 * @param bool $is_read_only True by default.
 	 * @return bool
 	 */
 	return (bool) apply_filters( 'aps_is_read_only', true );
@@ -207,7 +215,7 @@ function aps_is_excluded_post_type( $post_type ) {
 	 * Prevent the Archived status from being used on these post types.
 	 *
 	 * @since 0.1.0
-	 *
+	 * @param array $post_types An array of strings, the slugs for post types excluded.
 	 * @return array
 	 */
 	$excluded = (array) apply_filters( 'aps_excluded_post_types', array( 'attachment' ) );
@@ -223,11 +231,8 @@ function aps_is_excluded_post_type( $post_type ) {
 function aps_post_screen_js() {
 
 	global $post;
-
 	if ( aps_is_excluded_post_type( $post->post_type ) ) {
-
 		return;
-
 	}
 
 	if ( 'draft' !== $post->post_status && 'pending' !== $post->post_status ) {
@@ -266,9 +271,7 @@ function aps_edit_screen_js() {
 	global $typenow;
 
 	if ( aps_is_excluded_post_type( $typenow ) ) {
-
 		return;
-
 	}
 
 	?>
@@ -323,24 +326,16 @@ add_action( 'admin_footer-edit.php', 'aps_edit_screen_js' );
 function aps_load_post_screen() {
 
 	if ( ! aps_is_read_only() ) {
-
 		return;
-
 	}
 
-	$post_id = (int) filter_input( INPUT_GET, 'post', FILTER_SANITIZE_NUMBER_INT );
+	$post_id = absint( get_query_var( 'post' ) );
 	$post    = get_post( $post_id );
 
-	if (
-		is_null( $post )
-		||
-		aps_is_excluded_post_type( $post->post_type )
-		||
-		'archive' !== $post->post_status
-	) {
-
-		return;
-
+	if ( is_null( $post )
+		|| aps_is_excluded_post_type( $post->post_type )
+		|| 'archive' !== $post->post_status ) {
+			return;
 	}
 
 	$action  = esc_attr( get_query_var( 'action' ) );
@@ -382,16 +377,10 @@ add_action( 'load-post.php', 'aps_load_post_screen' );
  */
 function aps_display_post_states( $post_states, $post ) {
 
-	if (
-		aps_is_excluded_post_type( $post->post_type )
-		||
-		'archive' !== $post->post_status
-		||
-		'archive' === get_query_var( 'post_status' )
-	) {
-
-		return $post_states;
-
+	if ( aps_is_excluded_post_type( $post->post_type )
+			|| 'archive' !== $post->post_status
+			|| 'archive' === get_query_var( 'post_status' ) ) {
+				return $post_states;
 	}
 
 	return array_merge(
@@ -415,14 +404,9 @@ add_filter( 'display_post_states', 'aps_display_post_states', 10, 2 );
  */
 function aps_save_post( $post_id, $post, $update ) {
 
-	if (
-		aps_is_excluded_post_type( $post->post_type )
-		||
-		wp_is_post_revision( $post )
-	) {
-
-		return;
-
+	if ( aps_is_excluded_post_type( $post->post_type )
+			|| wp_is_post_revision( $post ) ) {
+				return;
 	}
 
 	if ( 'archive' === $post->post_status ) {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Bootstrap file for tests.
+ *
+ * @package ArchivedPostStatus
+ */
+
+define( 'APS_VERSION', '0.5.0' );
+
+$_tests_dir = getenv( 'WP_TESTS_DIR' );
+
+if ( ! $_tests_dir ) {
+	$_tests_dir = rtrim( sys_get_temp_dir(), '/\\' ) . '/wordpress-tests-lib';
+}
+
+if ( ! file_exists( $_tests_dir . '/includes/functions.php' ) ) {
+	echo "Could not find $_tests_dir/includes/functions.php, have you run bin/install-wp-tests.sh ?" . PHP_EOL; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	exit( 1 );
+}
+
+// Give access to tests_add_filter() function.
+require_once $_tests_dir . '/includes/functions.php';
+
+/**
+ * Manually load the plugin being tested.
+ */
+function _manually_load_plugin() {
+	require dirname( dirname( __FILE__ ) ) . '/archived-post-status.php';
+}
+tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
+
+// Start up the WP testing environment.
+require $_tests_dir . '/includes/bootstrap.php';

--- a/tests/php/FunctionsTest.php
+++ b/tests/php/FunctionsTest.php
@@ -30,6 +30,42 @@ class FunctionsTest extends TestCase {
 	}
 
 	/**
+	 * Test the aps_post_status_slug() function.
+	 *
+	 * @since 0.3.9
+	 */
+	public function test_aps_post_status_slug() {
+
+		$string = 'archive';
+
+		// Confirm the filter is applied.
+		\WP_Mock::expectFilter( 'aps_post_status_slug', $string );
+
+		// Confirm default condition is true.
+		$this->assertEquals( $string, aps_post_status_slug() );
+
+	}
+
+	/**
+	 * Test the aps_is_excluded_post_type() function filters.
+	 *
+	 * @since 0.3.9
+	 */
+	public function test_aps_post_status_slug_filter() {
+
+		$string = 'resolve';
+
+		// Pass false to the filter.
+		WP_Mock::onFilter( 'aps_post_status_slug' )
+			->with( 'archive' )
+			->reply( $string );
+
+		// Confirm the filter is applied.
+		$this->assertEquals( $string, aps_post_status_slug() );
+
+	}
+
+	/**
 	 * Test the aps_is_frontend() function.
 	 *
 	 * @since 0.3.9
@@ -192,7 +228,7 @@ class FunctionsTest extends TestCase {
 	 *
 	 * @since 0.3.9
 	 */
-	public function test_aps_is_excluded_post_type_filters() {
+	public function test_aps_is_excluded_post_type_filter() {
 
 		// Pass false to the filter.
 		WP_Mock::onFilter( 'aps_excluded_post_types' )

--- a/tests/php/FunctionsTest.php
+++ b/tests/php/FunctionsTest.php
@@ -40,7 +40,7 @@ class FunctionsTest extends TestCase {
 		// Return false, then true.
 		\WP_Mock::userFunction(
 			'is_admin', array(
-				'times'      => 2,
+				'times'           => 2,
 				'return_in_order' => array(
 					false,
 					true,
@@ -64,7 +64,7 @@ class FunctionsTest extends TestCase {
 		// Mock the current_user_can() function.
 		\WP_Mock::userFunction(
 			'current_user_can', array(
-				'times'  => 2,
+				'times'  => 1,
 				'return' => function( $capability ) {
 					return $capability === 'read_private_posts';
 				},
@@ -76,6 +76,25 @@ class FunctionsTest extends TestCase {
 
 		// Confirm the default condition is true.
 		$this->assertTrue( aps_current_user_can_view() );
+
+	}
+
+	/**
+	 * Test the aps_current_user_can_view() filter.
+	 *
+	 * @since 0.3.9
+	 */
+	public function test_aps_current_user_can_view_filter() {
+
+		// Mock the current_user_can() function.
+		\WP_Mock::userFunction(
+			'current_user_can', array(
+				'times'  => 1,
+				'return' => function( $capability ) {
+					return $capability === 'read_private_posts';
+				},
+			)
+		);
 
 		// Pass false to the filter.
 		WP_Mock::onFilter( 'aps_default_read_capability' )
@@ -99,6 +118,15 @@ class FunctionsTest extends TestCase {
 
 		// Confirm default condition is true.
 		$this->assertTrue( aps_is_read_only() );
+
+	}
+
+	/**
+	 * Test the aps_is_read_only() function filters.
+	 *
+	 * @since 0.3.9
+	 */
+	public function test_aps_is_read_only_filters() {
 
 		// Pass false to the filter.
 		WP_Mock::onFilter( 'aps_is_read_only' )
@@ -156,6 +184,15 @@ class FunctionsTest extends TestCase {
 		// Confirm default condition is true.
 		$this->assertTrue( aps_is_excluded_post_type( 'attachment' ) );
 		$this->assertFalse( aps_is_excluded_post_type( 'post' ) );
+
+	}
+
+	/**
+	 * Test the aps_is_excluded_post_type() function filters.
+	 *
+	 * @since 0.3.9
+	 */
+	public function test_aps_is_excluded_post_type_filters() {
 
 		// Pass false to the filter.
 		WP_Mock::onFilter( 'aps_excluded_post_types' )

--- a/tests/php/FunctionsTest.php
+++ b/tests/php/FunctionsTest.php
@@ -1,0 +1,268 @@
+<?php
+/**
+ * Class FunctionsTest
+ *
+ * @since 0.3.9
+ * @package ArchivedPostStatus
+ * @subpackage ClassFunctionsTest
+ */
+
+/**
+ * Sample test case.
+ *
+ * @since 0.3.9
+ */
+class FunctionsTest extends TestCase {
+
+	/**
+	 * Set up the test.
+	 *
+	 * @since 0.3.9
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		\WP_Mock::userFunction(
+			'__', array(
+				'return' => 'Archived',
+			)
+		);
+	}
+
+	/**
+	 * Test the aps_is_frontend() function.
+	 *
+	 * @since 0.3.9
+	 */
+	public function test_aps_is_frontend() {
+
+		// Confirm the is_admin() function is called.
+		// Return false, then true.
+		\WP_Mock::userFunction(
+			'is_admin', array(
+				'times'      => 2,
+				'return_in_order' => array(
+					false,
+					true,
+				),
+			)
+		);
+
+		// Is frontend should return the opposite of is_admin().
+		$this->assertTrue( aps_is_frontend() );
+		$this->assertFalse( aps_is_frontend() );
+
+	}
+
+	/**
+	 * Test the aps_current_user_can_view() function.
+	 *
+	 * @since 0.3.9
+	 */
+	public function test_aps_current_user_can_view() {
+
+		// Mock the current_user_can() function.
+		\WP_Mock::userFunction(
+			'current_user_can', array(
+				'times'  => 2,
+				'return' => function( $capability ) {
+					return $capability === 'read_private_posts';
+				},
+			)
+		);
+
+		// Confirm the filter is applied.
+		\WP_Mock::expectFilter( 'aps_default_read_capability', 'read_private_posts' );
+
+		// Confirm the default condition is true.
+		$this->assertTrue( aps_current_user_can_view() );
+
+		// Pass false to the filter.
+		WP_Mock::onFilter( 'aps_default_read_capability' )
+			->with( 'read_private_posts' )
+			->reply( 'read' );
+
+		// Confirm the filter is applied.
+		$this->assertFalse( aps_current_user_can_view() );
+
+	}
+
+	/**
+	 * Test the aps_is_read_only() function.
+	 *
+	 * @since 0.3.9
+	 */
+	public function test_aps_is_read_only() {
+
+		// Confirm the filter is applied.
+		\WP_Mock::expectFilter( 'aps_is_read_only', true );
+
+		// Confirm default condition is true.
+		$this->assertTrue( aps_is_read_only() );
+
+		// Pass false to the filter.
+		WP_Mock::onFilter( 'aps_is_read_only' )
+			->with( true )
+			->reply( false );
+
+		// Confirm the filter is applied.
+		$this->assertFalse( aps_is_read_only() );
+
+	}
+
+	/**
+	 * Test the aps_the_title() function.
+	 *
+	 * @since 0.3.9
+	 */
+	public function test_aps_the_title() {
+
+		// Mock WP post object.
+		$mock_post = \Mockery::mock( 'WP_Post' );
+		$mock_post->post_title = 'Test Title';
+		$mock_post->post_status = 'archive';
+		$mock_post->post_type = 'post';
+		$mock_post->ID = 86;
+
+		// Mock functions.
+		\WP_Mock::userFunction(
+			'get_post', array(
+				'times'  => 1,
+				'return' => $mock_post,
+			)
+		);
+		\WP_Mock::userFunction(
+			'is_admin', array(
+				'return' => false,
+			)
+		);
+
+		$new_title = aps_the_title( $mock_post->post_title, $mock_post->ID );
+
+		$this->assertEquals( 'Archived: ' . $mock_post->post_title, $new_title );
+
+	}
+
+	/**
+	 * Test the aps_is_excluded_post_type() function.
+	 *
+	 * @since 0.3.9
+	 */
+	public function test_aps_is_excluded_post_type() {
+
+		// Confirm the filter is applied.
+		\WP_Mock::expectFilter( 'aps_excluded_post_types', array( 'attachment' ) );
+
+		// Confirm default condition is true.
+		$this->assertTrue( aps_is_excluded_post_type( 'attachment' ) );
+		$this->assertFalse( aps_is_excluded_post_type( 'post' ) );
+
+		// Pass false to the filter.
+		WP_Mock::onFilter( 'aps_excluded_post_types' )
+			->with( 'attachment' )
+			->reply( array( ) );
+
+		// Confirm the filter is applied.
+		$this->assertFalse( aps_is_excluded_post_type( 'attachment' ) );
+
+	}
+
+	/**
+	 * Test the aps_display_post_states() function.
+	 *
+	 * @since 0.3.9
+	 */
+	public function test_aps_display_post_states() {
+
+		// Mock the aps_is_excluded_post_type() function.
+		\WP_Mock::userFunction(
+			'aps_is_excluded_post_type', array(
+				'times'  => 1,
+				'return' => false,
+			)
+		);
+
+		// Mock the get_query_var() function.
+		\WP_Mock::userFunction(
+			'get_query_var', array(
+				'times'  => 1,
+				'return' => false,
+			)
+		);
+
+		// Mock WP post object.
+		$mock_post = \Mockery::mock( 'WP_Post' );
+		$mock_post->post_status = 'archive';
+		$mock_post->post_type = 'post';
+
+		$mock_post_states = array( 'some-state' => 'Some state' );
+		$new_post_states = aps_display_post_states( $mock_post_states, $mock_post );
+
+		$this->assertArrayHasKey( 'archive', $new_post_states );
+		$this->assertEquals( 'Archived', $new_post_states['archive'] );
+
+	}
+
+	/**
+	 * Test the aps_save_post() function.
+	 *
+	 * @since 0.3.9
+	 */
+	public function test_aps_save_post() {
+
+		// Mock WP post object.
+		$mock_post = \Mockery::mock( 'WP_Post' );
+		$mock_post->post_status = 'archive';
+		$mock_post->post_type = 'post';
+		$mock_post->comment_status = 'open';
+		$mock_post->ping_status    = 'open';
+		$mock_post->ID = 86;
+
+		// Mock the wp_is_post_revision() function.
+		\WP_Mock::userFunction(
+			'wp_is_post_revision', array(
+				'return' => false,
+			)
+		);
+
+		// Mock the aps_is_excluded_post_type() function.
+		\WP_Mock::userFunction(
+			'aps_is_excluded_post_type', array(
+				'times'  => 1,
+				'return' => false,
+			)
+		);
+
+		// Mock the remove_action() function.
+		\WP_Mock::userFunction(
+			'remove_action', array(
+				'return' => true,
+			)
+		);
+
+		// Mock the wp_update_post() function.
+		\WP_Mock::userFunction(
+			'wp_update_post', array(
+				'times'  => 1,
+				'args'   => array(
+					array(
+						'ID' => $mock_post->ID,
+						'comment_status' => 'closed',
+						'ping_status'    => 'closed',
+					),
+				),
+				'return' => function( $args ) use ( $mock_post ) {
+					$mock_post->comment_status = $args['comment_status'];
+					$mock_post->ping_status    = $args['ping_status'];
+					return $mock_post->ID;
+				},
+			)
+		);
+
+		aps_save_post( $mock_post->ID, $mock_post, true );
+
+		$this->assertEquals( 'closed', $mock_post->comment_status );
+		$this->assertEquals( 'closed', $mock_post->ping_status );
+
+	}
+}

--- a/tests/php/FunctionsTest.php
+++ b/tests/php/FunctionsTest.php
@@ -30,6 +30,42 @@ class FunctionsTest extends TestCase {
 	}
 
 	/**
+	 * Test the aps_archived_label_string() function.
+	 *
+	 * @since 0.3.9
+	 */
+	public function test_aps_archived_label_string() {
+
+		$string = 'Archived';
+
+		// Confirm the filter is applied.
+		\WP_Mock::expectFilter( 'aps_archived_label_string', $string );
+
+		// Confirm default condition is true.
+		$this->assertEquals( $string, aps_archived_label_string() );
+
+	}
+
+	/**
+	 * Test the aps_is_excluded_post_type() function filters.
+	 *
+	 * @since 0.3.9
+	 */
+	public function test_aps_archived_label_string_filter() {
+
+		$string = 'Resolved';
+
+		// Pass false to the filter.
+		WP_Mock::onFilter( 'aps_archived_label_string' )
+			->with( 'Archived' )
+			->reply( $string );
+
+		// Confirm the filter is applied.
+		$this->assertEquals( $string, aps_archived_label_string() );
+
+	}
+
+	/**
 	 * Test the aps_post_status_slug() function.
 	 *
 	 * @since 0.3.9

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Bootsrap file for tests.
+ *
+ * @package ArchivedPostStatus
+ */
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+WP_Mock::setUsePatchwork( true );
+WP_Mock::bootstrap();
+
+define( 'PLUGIN_PATH', dirname( __DIR__, 2 ) );
+
+require_once __DIR__ . '/includes/common.php';
+require_once __DIR__ . '/includes/TestCase.php';
+
+// Load plugin files.
+require_once PLUGIN_PATH . '/src/archived-post-status.php';

--- a/tests/php/includes/TestCase.php
+++ b/tests/php/includes/TestCase.php
@@ -1,0 +1,59 @@
+<?php
+
+use Yoast\PHPUnitPolyfills\TestCases\TestCase as BaseTestCase;
+
+/**
+ * We will extend this test case to make WP_Mock set up easier
+ */
+class TestCase extends BaseTestCase {
+
+	/**
+	 * Set up with WP_Mock
+	 *
+	 * @since  0.8
+	 */
+	public function set_up() {
+		\WP_Mock::setUp();
+		$this->setup_common();
+	}
+
+	/**
+	 * Tear down with WP_Mock
+	 *
+	 * @since  0.8
+	 */
+	public function tear_down() {
+		\WP_Mock::tearDown();
+	}
+
+	/**
+	 * Mock common functions
+	 *
+	 * @since 0.8
+	 */
+	public function setup_common() {
+		\WP_Mock::userFunction(
+			'__', array(
+				'return_arg' => 0,
+			)
+		);
+
+		\WP_Mock::userFunction(
+			'esc_html__', array(
+				'return_arg' => 0,
+			)
+		);
+
+		\WP_Mock::userFunction(
+			'esc_html_e', array(
+				'return_arg' => 0,
+			)
+		);
+
+		\WP_Mock::userFunction(
+			'_e', array(
+				'return_arg' => 0,
+			)
+		);
+	}
+}

--- a/tests/php/includes/common.php
+++ b/tests/php/includes/common.php
@@ -6,7 +6,7 @@
 /**
  * Mock wp_cache_get() function.
  *
- * @since x.x.x
+ * @since 0.3.9
  *
  * @param string $key
  * @param string $group
@@ -19,7 +19,7 @@ function wp_cache_get( $key, $group ) {
 /**
  * Mock wp_cache_set() function.
  *
- * @since x.x.x
+ * @since 0.3.9
  *
  * @param string $key
  * @param mixed  $value
@@ -33,7 +33,7 @@ function wp_cache_set( $key, $value, $group ) {
 /**
  * Mock absint() function.
  *
- * @since x.x.x
+ * @since 0.3.9
  *
  * @param mixed $maybeint
  * @return int

--- a/tests/php/includes/common.php
+++ b/tests/php/includes/common.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Simple common WP classes/functions
+ */
+
+/**
+ * Mock wp_cache_get() function.
+ *
+ * @since x.x.x
+ *
+ * @param string $key
+ * @param string $group
+ * @return mixed
+ */
+function wp_cache_get( $key, $group ) {
+	return false;
+}
+
+/**
+ * Mock wp_cache_set() function.
+ *
+ * @since x.x.x
+ *
+ * @param string $key
+ * @param mixed  $value
+ * @param string $group
+ * @return bool
+ */
+function wp_cache_set( $key, $value, $group ) {
+	return true;
+}
+
+/**
+ * Mock absint() function.
+ *
+ * @since x.x.x
+ *
+ * @param mixed $maybeint
+ * @return int
+ */
+function absint( $maybeint ) {
+	return abs( (int) $maybeint );
+}
+
+/**
+ * Mock _n_noop() function.
+ */
+function _n_noop( $singular, $plural, $domain = null ) {
+	return array(
+		0          => $singular,
+		1          => $plural,
+		'singular' => $singular,
+		'plural'   => $plural,
+		'context'  => null,
+		'domain'   => $domain,
+	);
+}


### PR DESCRIPTION
Updating some deprecated functions and addressing some bugs.

Update Includes:
- Fix deprecated php warning on `filter_input`, using native WP functions for escaping & getting query var. Fixes another issue, where archived posts couldn't be trashed (Closes #35)
- Add `aps_archived_label_string` filter to modify the "Archived" string used for the status label throughout the plugin.
- Add `aps_title_separator` and `aps_title_label` to filter the post title separator and label. It defaults to 'Archived' with a `:` separator as a prefix to the content title. Disable the title label entirely by using `add_filter( 'aps_title_prefix', '__return_false' );` in your `functions.php` file or custom plugin file. Closes #21
- Added `aps_title_label_before` filter, defaults to `true` - pass `false` to have the label appear after the title instead of before it, in which case it appears as "- Archived." This change along with the label string filter above closes #31
- Add PHPUnit tests & github actions.
- Update some comments and documentation, readmes, etc