### PR TITLE
Tests: Playwright browser + CLI end-to-end suites

### DIFF
--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -1,0 +1,128 @@
+name: "E2E Tests"
+
+on:
+  pull_request:
+    branches:
+    - stable
+    - "release/**"
+  workflow_dispatch: null
+
+permissions:
+  contents: "read"
+
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
+jobs:
+  playwright:
+    name: "WP ${{ matrix.wp }} / PHP ${{ matrix.php }} E2E"
+    runs-on: "ubuntu-latest"
+    # A cold wp-env start (image pull + core download) dominates the wall clock;
+    # the suite itself is ~2 minutes. 60 leaves room for CI retries.
+    timeout-minutes: 60
+    # Development WordPress is upstream code this repo does not control: it
+    # reports, it does not block a merge. Everything else is a hard gate.
+    continue-on-error: ${{ matrix.wp == 'master' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # Explicit combinations rather than a cross product: the support surface
+        # is "current WP on every supported PHP" plus one older WP and one newer
+        # WP on the version we develop against.
+        include:
+        # readme.txt "Requires PHP: 8.1" - the floor has to run green.
+        - wp: "latest"
+          php: "8.1"
+        # .wp-env.json phpVersion - parity with local development.
+        - wp: "latest"
+          php: "8.3"
+        # Top of the PHP range the unit-test matrix already covers.
+        - wp: "latest"
+          php: "8.4"
+        # The declared "Tested up to: 7.0" line, at its newest patch. WordPress.org
+        # only accepts major.minor in that header, so the readme says 7.0 while
+        # this pins the actual build the claim was verified against.
+        - wp: "7.0.2"
+          php: "8.3"
+        # Development WordPress, for early warning on upstream core changes.
+        # "master", not "trunk": the WordPress/WordPress mirror has no `trunk`
+        # ref, despite the example in the @wordpress/env README.
+        - wp: "master"
+          php: "8.3"
+
+    env:
+      # wp-env reads this on every invocation (start, run, stop), so it is set
+      # for the whole job rather than written into .wp-env.override.json - the
+      # override file is owned by tests/bin/set-core-version.js.
+      WP_ENV_PHP_VERSION: "${{ matrix.php }}"
+
+    steps:
+    - name: "Checkout"
+      uses: "actions/checkout@v6"
+
+    - name: "Setup Node.js"
+      uses: "actions/setup-node@v5"
+      with:
+        node-version: "22"
+        cache: "npm"
+
+    - name: "Install npm dependencies"
+      run: "npm ci"
+
+    # Only chromium: playwright.config.ts defines a single browser project.
+    - name: "Install the Playwright browser"
+      run: "npx playwright install --with-deps chromium"
+
+    # Writes .wp-env.override.json for a pinned version; "latest" deletes it.
+    - name: "Pin the WordPress core version"
+      env:
+        APS_WP_VERSION: "${{ matrix.wp }}"
+      run: |
+        npm run test:e2e:core-version -- "${APS_WP_VERSION}"
+        cat .wp-env.override.json || echo "No override written: latest stable."
+
+    # First run on a fresh runner pulls the Docker images and downloads core.
+    - name: "Start wp-env"
+      id: wp-env
+      timeout-minutes: 30
+      run: "npm run env:start"
+
+    # Cheap, and it puts the versions actually under test in the job log.
+    - name: "Report the environment under test"
+      run: |
+        npx wp-env run tests-cli -- wp core version
+        npx wp-env run tests-cli -- php -r 'echo PHP_VERSION, PHP_EOL;'
+
+    - name: "Browser suite"
+      run: "npm run test:e2e"
+
+    # Sequential with the browser suite on purpose: both target the tests
+    # instance on :8889 and the Playwright global setup wipes all posts.
+    #
+    # It still runs when the browser suite fails - the group seeds and tears
+    # down its own posts, so it is independent signal, and a matrix leg costs a
+    # cold image pull to repeat. It does NOT run when wp-env never came up,
+    # which would only produce guaranteed-fail noise.
+    - name: "WP-CLI regression group"
+      if: ${{ !cancelled() && steps.wp-env.outcome == 'success' }}
+      run: "npm run test:e2e:cli"
+
+    - name: "Collect the WordPress debug log"
+      if: failure()
+      continue-on-error: true
+      run: |
+        mkdir -p artifacts
+        npx wp-env run tests-cli -- cat /var/www/html/wp-content/debug.log > artifacts/debug.log
+
+    # WP_ARTIFACTS_PATH (playwright.config.ts) is <repo>/artifacts, and
+    # outputDir is artifacts/test-results - traces, screenshots and videos.
+    # Authentication state lives in playwright/.auth/ and is deliberately not
+    # uploaded.
+    - name: "Upload failure artifacts"
+      if: failure()
+      uses: "actions/upload-artifact@v4"
+      with:
+        name: "e2e-wp${{ matrix.wp }}-php${{ matrix.php }}-${{ github.run_id }}"
+        path: "artifacts/"
+        retention-days: 7

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -8,5 +8,8 @@
 	"phpVersion": "8.3",
 	"plugins": [
 		"."
-	]
+	],
+	"mappings": {
+		"wp-content/mu-plugins": "./tests/e2e/fixtures"
+	}
 }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,10 @@
     "env:db-info": "echo 'WordPress Database Connection Details:' && echo 'Host: localhost' && echo 'Port:' $(docker ps --format 'table {{.Names}}\t{{.Ports}}' | grep mysql | head -1 | grep -o '0.0.0.0:[0-9]*->3306' | cut -d: -f2 | cut -d- -f1) && echo 'Database: wordpress' && echo 'Username: root' && echo 'Password: password' && echo '' && echo 'All MySQL containers:' && docker ps --format 'table {{.Names}}\t{{.Ports}}' | grep mysql",
     "test": "jest --verbose --runInBand --detectOpenHandles --forceExit",
     "test:watch": "jest --watch",
-    "test:coverage": "jest --coverage"
+    "test:coverage": "jest --coverage",
+    "test:e2e": "wp-scripts test-e2e --config playwright.config.ts",
+    "test:e2e:cli": "bash ./tests/e2e/cli/run.sh",
+    "test:e2e:core-version": "node ./tests/bin/set-core-version.js"
   },
   "devDependencies": {
     "@babel/core": "^7.23.9",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,88 @@
+/**
+ * External dependencies
+ */
+import path from 'node:path';
+import { defineConfig, devices } from '@playwright/test';
+import type { PlaywrightTestConfig } from '@playwright/test';
+
+/**
+ * Internal dependencies
+ */
+import { ADMIN_STORAGE_STATE } from './tests/e2e/config/roles';
+
+/**
+ * Port of the wp-env *tests* instance (see `.wp-env.json`).
+ *
+ * wp-env 11 defaults `port`/`testsPort` to auto-select, so both are pinned in
+ * `.wp-env.json` and the tests port is repeated here for the web server check.
+ */
+const TESTS_PORT = 8889;
+
+// `@wordpress/scripts`' shared Playwright config reads these at require time,
+// so they have to be set before it is loaded. Pointing `STORAGE_STATE_PATH` at
+// our admin state keeps the `requestUtils` worker fixture and the browser
+// projects on a single file.
+process.env.WP_ARTIFACTS_PATH ??= path.join( __dirname, 'artifacts' );
+process.env.STORAGE_STATE_PATH ??= ADMIN_STORAGE_STATE;
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires -- deliberately loaded after the env vars above.
+const baseConfig: PlaywrightTestConfig = require( '@wordpress/scripts/config/playwright.config.js' );
+
+/**
+ * E2E configuration for the Archived Post Status plugin.
+ *
+ * Starts from the WordPress core defaults shipped by `@wordpress/scripts` and
+ * overrides only what this plugin needs: our own test tree, our own global
+ * setup, and the wp-env tests instance as the web server.
+ */
+export default defineConfig( {
+	...baseConfig,
+
+	// `specs/` holds UI specs, `cli/` holds WP-CLI specs.
+	testDir: path.join( __dirname, 'tests', 'e2e' ),
+
+	// Resolved relative to this config file.
+	globalSetup: './tests/e2e/config/global-setup.ts',
+
+	// `@wordpress/scripts`' base config already sets this to 1, but only as an
+	// inherited default — this repo never pins it itself, so a future upstream
+	// config change could silently parallelise workers. The whole suite (CLI
+	// specs included) shares one wp-env site and assumes serial execution:
+	// `global-setup.ts` wipes all content once up front rather than per test,
+	// and specs seed/clean up against that single shared site. Pinned here so
+	// the assumption is enforced by this repo, not borrowed from upstream.
+	workers: 1,
+
+	use: {
+		...baseConfig.use,
+		storageState: ADMIN_STORAGE_STATE,
+		trace: 'retain-on-failure',
+	},
+
+	webServer: {
+		command: 'npm run env:start',
+		port: TESTS_PORT,
+		timeout: 600_000,
+		reuseExistingServer: true,
+	},
+
+	projects: [
+		{
+			name: 'chromium',
+			use: {
+				...devices[ 'Desktop Chrome' ],
+				// Specs run as administrator unless they opt into another
+				// role with `test.use( { storageState: storageStatePath( 'editor' ) } )`.
+				storageState: ADMIN_STORAGE_STATE,
+			},
+			testMatch: /.*\.spec\.ts$/,
+			dependencies: [ 'auth' ],
+		},
+		// Firefox and WebKit are deliberately deferred; chromium is the only
+		// browser the 0.4.0 suite targets.
+		{
+			name: 'auth',
+			testMatch: /auth\.setup\.ts$/,
+		},
+	],
+} );

--- a/tests/bin/set-core-version.js
+++ b/tests/bin/set-core-version.js
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+
+const fs = require("fs");
+const { exit } = require("process");
+
+const path = `${process.cwd()}/.wp-env.override.json`;
+
+let config = fs.existsSync(path) ? require(path) : {};
+
+const args = process.argv.slice(2);
+
+if (args.length == 0) exit(0);
+
+if (args[0] == "latest") {
+  if (fs.existsSync(path)) {
+    fs.unlinkSync(path);
+  }
+  exit(0);
+}
+
+config.core = args[0];
+
+if (!config.core.match(/^WordPress\/WordPress\#/)) {
+  config.core = "WordPress/WordPress#" + config.core;
+}
+
+try {
+  fs.writeFileSync(path, JSON.stringify(config));
+} catch (err) {
+  console.error(err);
+  exit(1);
+}

--- a/tests/e2e/cli/run.sh
+++ b/tests/e2e/cli/run.sh
@@ -1,0 +1,429 @@
+#!/usr/bin/env bash
+#
+# WP-CLI regression group for the 0.4.0 release.
+#
+# Runs `wp post archive` / `wp post unarchive` inside the wp-env tests container
+# and asserts on BOTH the command exit code and the post status read back with
+# `wp post get`. Exits non-zero if any assertion fails.
+#
+# Usage:
+#   npm run test:e2e:cli
+#   APS_CLI_CONTAINER=cli ./tests/e2e/cli/run.sh   # run against the dev site
+#
+# Fixtures used (see tests/e2e/fixtures/, all reset on exit):
+#   aps_test_cap_filter_enabled         archive/unarchive capability -> manage_options
+#   aps_test_restrict_statuses_enabled  archivable statuses -> publish only
+#
+set -uo pipefail
+
+REPO_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../../.." && pwd )"
+WP_ENV="${REPO_ROOT}/node_modules/.bin/wp-env"
+CONTAINER="${APS_CLI_CONTAINER:-tests-cli}"
+EDITOR_LOGIN="aps_editor"
+
+cd "${REPO_ROOT}" || exit 1
+
+if [ ! -x "${WP_ENV}" ]; then
+	echo "wp-env not found at ${WP_ENV}; run npm install first." >&2
+	exit 1
+fi
+
+# An explicit template rather than `mktemp -t <prefix>`: BSD mktemp (macOS)
+# appends the random suffix itself, but GNU coreutils (every Linux CI runner)
+# rejects a template with no X's outright.
+STDERR_FILE="$( mktemp "${TMPDIR:-/tmp}/aps-cli-stderr.XXXXXX" )"
+# Created ids are recorded in a file rather than an array: `create_post` is
+# called from a command substitution, and an array append inside that subshell
+# would never reach this process.
+CREATED_IDS_FILE="$( mktemp "${TMPDIR:-/tmp}/aps-cli-ids.XXXXXX" )"
+PASSED=0
+FAILED=0
+
+# ---------------------------------------------------------------------------
+# Harness
+# ---------------------------------------------------------------------------
+
+# Run a `wp` command in the container. Sets WP_EXIT / WP_OUT / WP_ERR.
+run_wp() {
+	WP_OUT="$( "${WP_ENV}" run "${CONTAINER}" -- wp "$@" 2>"${STDERR_FILE}" )"
+	WP_EXIT=$?
+	WP_ERR="$( cat "${STDERR_FILE}" )"
+}
+
+pass() {
+	PASSED=$(( PASSED + 1 ))
+	printf '  ok   %s\n' "$1"
+}
+
+fail() {
+	FAILED=$(( FAILED + 1 ))
+	printf '  FAIL %s\n' "$1"
+	printf '       %s\n' "$2"
+}
+
+assert_exit() {
+	local expected="$1" label="$2"
+
+	if [ "${WP_EXIT}" = "${expected}" ]; then
+		pass "${label} (exit ${WP_EXIT})"
+	else
+		fail "${label}" "expected exit ${expected}, got ${WP_EXIT}: ${WP_ERR}"
+	fi
+}
+
+assert_exit_nonzero() {
+	local label="$1"
+
+	if [ "${WP_EXIT}" != "0" ]; then
+		pass "${label} (exit ${WP_EXIT})"
+	else
+		fail "${label}" "expected a non-zero exit, got 0: ${WP_OUT}"
+	fi
+}
+
+assert_eq() {
+	local expected="$1" actual="$2" label="$3"
+
+	if [ "${expected}" = "${actual}" ]; then
+		pass "${label} (${actual})"
+	else
+		fail "${label}" "expected '${expected}', got '${actual}'"
+	fi
+}
+
+assert_contains() {
+	local haystack="$1" needle="$2" label="$3"
+
+	case "${haystack}" in
+		*"${needle}"*) pass "${label}" ;;
+		*) fail "${label}" "expected to find '${needle}' in: ${haystack}" ;;
+	esac
+}
+
+# Echo a post's current status.
+post_status() {
+	"${WP_ENV}" run "${CONTAINER}" -- wp post get "$1" --field=post_status 2>/dev/null
+}
+
+assert_status() {
+	assert_eq "$1" "$( post_status "$2" )" "$3"
+}
+
+# Create a post and remember it for teardown. Echoes the new id.
+create_post() {
+	local status="$1" title="$2" id
+
+	id="$( "${WP_ENV}" run "${CONTAINER}" -- wp post create \
+		--post_type=post --post_status="${status}" --post_title="${title}" \
+		--comment_status=open --ping_status=open --porcelain 2>/dev/null )"
+
+	echo "${id}" >>"${CREATED_IDS_FILE}"
+	echo "${id}"
+}
+
+# Create N posts in ONE container call and remember them for teardown.
+# Echoes the new ids, comma separated.
+#
+# The progress-bar branch of CommandRunner only engages above 20 ids, so that
+# case needs 21 posts; created one at a time that would cost ~25s of Docker
+# startup on its own.
+create_posts() {
+	local count="$1" status="$2" title="$3" ids
+
+	ids="$( "${WP_ENV}" run "${CONTAINER}" -- wp eval "
+		\$ids = array();
+		for ( \$i = 1; \$i <= ${count}; \$i++ ) {
+			\$ids[] = wp_insert_post( array(
+				'post_type'   => 'post',
+				'post_status' => '${status}',
+				'post_title'  => '${title} ' . \$i,
+			) );
+		}
+		echo implode( ',', \$ids );
+	" 2>/dev/null )"
+
+	echo "${ids}" | tr ',' '\n' >>"${CREATED_IDS_FILE}"
+	echo "${ids}"
+}
+
+# Echo how many of the given (comma-separated) ids carry the archived status.
+count_archived() {
+	"${WP_ENV}" run "${CONTAINER}" -- wp eval "
+		\$archived = 0;
+		foreach ( array( $1 ) as \$id ) {
+			if ( 'archive' === get_post_status( \$id ) ) {
+				\$archived++;
+			}
+		}
+		echo \$archived;
+	" 2>/dev/null
+}
+
+set_option() {
+	"${WP_ENV}" run "${CONTAINER}" -- wp option update "$1" "$2" >/dev/null 2>&1
+}
+
+delete_option() {
+	"${WP_ENV}" run "${CONTAINER}" -- wp option delete "$1" >/dev/null 2>&1
+}
+
+cleanup() {
+	local ids=()
+
+	delete_option aps_test_cap_filter_enabled
+	delete_option aps_test_restrict_statuses_enabled
+
+	while IFS= read -r id; do
+		[ -n "${id}" ] && ids+=( "${id}" )
+	done <"${CREATED_IDS_FILE}"
+
+	if [ ${#ids[@]} -gt 0 ]; then
+		# One `wp eval` rather than `wp post delete <ids>`: WP-CLI aborts the
+		# whole batch on the first id it cannot delete, which would strand the
+		# rest. Teardown has to be tolerant.
+		local csv
+		csv="$( IFS=,; echo "${ids[*]}" )"
+
+		"${WP_ENV}" run "${CONTAINER}" -- wp eval \
+			"foreach ( array( ${csv} ) as \$id ) { wp_delete_post( \$id, true ); }" \
+			>/dev/null 2>&1
+	fi
+
+	rm -f "${STDERR_FILE}" "${CREATED_IDS_FILE}"
+}
+trap cleanup EXIT
+
+section() {
+	printf '\n%s\n' "$1"
+}
+
+# ---------------------------------------------------------------------------
+# 1. `--user` respects aps_default_archive_capability (the A6/A7 class)
+# ---------------------------------------------------------------------------
+
+section '1. capability filter is enforced for an authenticated CLI user'
+
+POST_CAP_OK="$( create_post publish 'CLI cap allowed' )"
+POST_CAP_DENIED="$( create_post publish 'CLI cap denied' )"
+
+# Stock capability (edit_others_posts): the editor is allowed.
+run_wp post archive "${POST_CAP_OK}" --user="${EDITOR_LOGIN}"
+assert_exit 0 'editor archives with the default capability'
+assert_status archive "${POST_CAP_OK}" 'post is archived'
+
+# Filtered to manage_options: the same editor is refused.
+set_option aps_test_cap_filter_enabled 1
+
+run_wp post archive "${POST_CAP_DENIED}" --user="${EDITOR_LOGIN}"
+assert_exit_nonzero 'editor is refused once the capability is filtered'
+assert_contains "${WP_ERR}" 'does not have capability to archive' 'refusal names the capability check'
+assert_status publish "${POST_CAP_DENIED}" 'refused post keeps its status'
+
+# The unarchive capability filter is enforced on the same terms.
+run_wp post unarchive "${POST_CAP_OK}" --user="${EDITOR_LOGIN}"
+assert_exit_nonzero 'editor is refused unarchive once the capability is filtered'
+assert_contains "${WP_ERR}" 'does not have capability to unarchive' 'refusal names the unarchive check'
+assert_status archive "${POST_CAP_OK}" 'refused post is still archived'
+
+# ---------------------------------------------------------------------------
+# 2. Anonymous CLI bypasses the capability gate (documented behaviour)
+# ---------------------------------------------------------------------------
+
+section '2. anonymous CLI bypasses the capability gate'
+
+# The filter from section 1 is still on, so this only passes if the gate really
+# is skipped when there is no current user (Command::capability_check()).
+run_wp post archive "${POST_CAP_DENIED}"
+assert_exit 0 'anonymous CLI archives despite the manage_options filter'
+assert_status archive "${POST_CAP_DENIED}" 'post is archived'
+
+run_wp post unarchive "${POST_CAP_DENIED}"
+assert_exit 0 'anonymous CLI unarchives despite the filter'
+assert_status publish "${POST_CAP_DENIED}" 'post is restored to its previous status'
+
+delete_option aps_test_cap_filter_enabled
+
+# ---------------------------------------------------------------------------
+# 3. Multiple ids in one invocation
+# ---------------------------------------------------------------------------
+
+section '3. multi-id invocation'
+
+MULTI_ONE="$( create_post publish 'CLI multi one' )"
+MULTI_TWO="$( create_post draft 'CLI multi two' )"
+MULTI_THREE="$( create_post pending 'CLI multi three' )"
+
+run_wp post archive "${MULTI_ONE}" "${MULTI_TWO}" "${MULTI_THREE}"
+assert_exit 0 'three ids archive in one invocation'
+assert_contains "${WP_OUT}" 'archived post' 'per-post output is emitted below the count limit'
+assert_status archive "${MULTI_ONE}" 'first post archived'
+assert_status archive "${MULTI_TWO}" 'second post archived'
+assert_status archive "${MULTI_THREE}" 'third post archived'
+
+run_wp post unarchive "${MULTI_ONE}" "${MULTI_TWO}" "${MULTI_THREE}"
+assert_exit 0 'three ids unarchive in one invocation'
+assert_status publish "${MULTI_ONE}" 'first post restored to publish'
+assert_status draft "${MULTI_TWO}" 'second post restored to draft'
+assert_status pending "${MULTI_THREE}" 'third post restored to pending'
+
+# ---------------------------------------------------------------------------
+# 3b. The exit status reflects ANY failed item, at any batch size
+#
+# CommandRunner::run() accumulates the per-item status with max(), so the exit
+# code is independent of ordering and of which output branch ran. Both cases
+# below exited 0 before that fix (phase-2b Finding 1); the >20-id case is the
+# more dangerous one, because ordering cannot rescue it.
+# ---------------------------------------------------------------------------
+
+section '3b. exit status reflects any failed item'
+
+MIXED_FAIL="$( create_post publish 'CLI mixed failing' )"
+MIXED_OK="$( create_post publish 'CLI mixed ok' )"
+
+# An already-archived post is the cheapest deterministic failure: ArchiveCommand
+# rejects it before any capability work.
+run_wp post archive "${MIXED_FAIL}"
+assert_exit 0 'seed: the failing id is archived up front'
+
+run_wp post archive "${MIXED_FAIL}" "${MIXED_OK}"
+assert_exit_nonzero 'a batch whose FIRST item fails exits non-zero'
+assert_contains "${WP_ERR}" 'is already archived' 'the failure is reported'
+assert_status archive "${MIXED_OK}" 'the later valid id is still archived'
+
+# Above the count limit the per-post emit is replaced by a progress bar. The
+# exit code must survive that swap.
+BULK_IDS="$( create_posts 21 publish 'CLI bulk' )"
+BULK_FAIL="${BULK_IDS%%,*}"
+
+run_wp post archive "${BULK_FAIL}"
+assert_exit 0 'seed: one id inside the large batch is already archived'
+
+# shellcheck disable=SC2086 -- deliberate word splitting: 21 positional ids.
+run_wp post archive ${BULK_IDS//,/ }
+assert_exit_nonzero 'a 21-id batch containing one failure exits non-zero'
+assert_eq '' "${WP_OUT}" 'per-post output is suppressed above the count limit'
+assert_eq 21 "$( count_archived "${BULK_IDS}" )" 'every valid id in the large batch is archived'
+
+# ---------------------------------------------------------------------------
+# 4. --force skips the archivable-status whitelist
+# ---------------------------------------------------------------------------
+
+section '4. --force'
+
+FORCE_POST="$( create_post draft 'CLI force draft' )"
+
+set_option aps_test_restrict_statuses_enabled 1
+
+run_wp post archive "${FORCE_POST}"
+assert_exit_nonzero 'a non-archivable status is refused'
+assert_contains "${WP_ERR}" 'is not an archivable status' 'refusal names the status check'
+assert_status draft "${FORCE_POST}" 'refused post keeps its status'
+
+run_wp post archive "${FORCE_POST}" --force
+assert_exit 0 '--force archives the same post'
+assert_status archive "${FORCE_POST}" 'forced post is archived'
+
+delete_option aps_test_restrict_statuses_enabled
+
+# An already-archived post is refused before any capability work.
+run_wp post archive "${FORCE_POST}"
+assert_exit_nonzero 'archiving an archived post is refused'
+assert_contains "${WP_ERR}" 'is already archived' 'refusal says the post is already archived'
+
+# ---------------------------------------------------------------------------
+# 5. --status overrides the restored status on unarchive
+# ---------------------------------------------------------------------------
+
+section '5. --status on unarchive'
+
+STATUS_POST="$( create_post publish 'CLI status override' )"
+
+run_wp post archive "${STATUS_POST}"
+assert_exit 0 'post archived before the override'
+
+run_wp post unarchive "${STATUS_POST}" --status=draft
+assert_exit 0 'unarchive with --status succeeds'
+assert_status draft "${STATUS_POST}" '--status wins over the recorded previous status'
+
+# ---------------------------------------------------------------------------
+# 6. --defer-term-counting runs, and always restores term counting
+# ---------------------------------------------------------------------------
+
+section '6. --defer-term-counting'
+
+DEFER_POST="$( create_post publish 'CLI defer counting' )"
+
+run_wp post archive "${DEFER_POST}" --defer-term-counting
+assert_exit 0 '--defer-term-counting archives the post'
+assert_status archive "${DEFER_POST}" 'deferred-counting post is archived'
+
+run_wp post unarchive "${DEFER_POST}" --defer-term-counting
+assert_exit 0 '--defer-term-counting unarchives the post'
+assert_status publish "${DEFER_POST}" 'deferred-counting post is restored'
+
+# The try/finally guardrail can only be observed inside the process that set the
+# flag, so the two cases below run the command object directly under `wp eval`.
+# `wp_defer_term_counting()` with no argument returns the current state.
+DEFER_SUCCESS_POST="$( create_post publish 'CLI defer success' )"
+
+run_wp eval "
+\$command = new \\ArchivedPostStatus\\CLI\\ArchiveCommand();
+\$result  = \$command->run( ${DEFER_SUCCESS_POST}, array( 'defer-term-counting' => true ) );
+echo wp_json_encode( array(
+	'success'  => \$result->is_success,
+	'deferred' => wp_defer_term_counting(),
+) );
+"
+assert_exit 0 'eval harness ran for the success path'
+assert_eq '{"success":true,"deferred":false}' "${WP_OUT}" 'term counting is restored after a successful archive'
+
+DEFER_FAILURE_POST="$( create_post publish 'CLI defer failure' )"
+
+run_wp eval "
+add_filter( 'aps_pre_archive_post', '__return_false' );
+\$command = new \\ArchivedPostStatus\\CLI\\ArchiveCommand();
+\$result  = \$command->run( ${DEFER_FAILURE_POST}, array( 'defer-term-counting' => true ) );
+echo wp_json_encode( array(
+	'success'  => \$result->is_success,
+	'deferred' => wp_defer_term_counting(),
+) );
+"
+assert_exit 0 'eval harness ran for the failure path'
+assert_eq '{"success":false,"deferred":false}' "${WP_OUT}" 'term counting is restored after a failed archive'
+assert_status publish "${DEFER_FAILURE_POST}" 'vetoed post keeps its status'
+
+# ---------------------------------------------------------------------------
+# 7. Unsupported post type is rejected before any other validation
+#
+# `attachment` is public but excluded from `aps_get_supported_post_types()`
+# by default (SupportedPostTypes::all()'s `aps_excluded_post_types` filter),
+# so it is the cheapest post type that is real yet unsupported — no CPT
+# registration needed.
+# ---------------------------------------------------------------------------
+
+section '7. unsupported post type gate'
+
+UNSUPPORTED_POST="$( "${WP_ENV}" run "${CONTAINER}" -- wp post create \
+	--post_type=attachment --post_status=inherit \
+	--post_title='CLI unsupported post type' --porcelain 2>/dev/null )"
+echo "${UNSUPPORTED_POST}" >>"${CREATED_IDS_FILE}"
+
+run_wp post archive "${UNSUPPORTED_POST}"
+assert_exit_nonzero 'archive refuses an unsupported post type'
+assert_contains "${WP_ERR}" 'is not a supported post type' 'refusal names the post-type check'
+assert_status inherit "${UNSUPPORTED_POST}" 'refused post keeps its status'
+
+run_wp post unarchive "${UNSUPPORTED_POST}"
+assert_exit_nonzero 'unarchive refuses an unsupported post type'
+assert_contains "${WP_ERR}" 'is not a supported post type' 'refusal names the post-type check'
+assert_status inherit "${UNSUPPORTED_POST}" 'refused post keeps its status'
+
+# ---------------------------------------------------------------------------
+
+section "Result: ${PASSED} passed, ${FAILED} failed."
+
+if [ "${FAILED}" -gt 0 ]; then
+	exit 1
+fi
+
+exit 0

--- a/tests/e2e/config/admin.ts
+++ b/tests/e2e/config/admin.ts
@@ -1,0 +1,198 @@
+/**
+ * Locators and URL builders for the post list table screen (`edit.php`).
+ *
+ * Shared by the post-list, editor and role specs so the screen's markup
+ * contract lives in one place: if WordPress renames the notice container or the
+ * bulk-action controls, exactly one file changes.
+ */
+
+/**
+ * External dependencies
+ */
+import type { Locator, Page } from '@playwright/test';
+
+/**
+ * The theme renders the post title through the post-title block, which is what
+ * runs the `the_title` filter on the front end. Scoped to the `h1` because the
+ * single template reuses the same block class for the related-posts headings
+ * further down the page.
+ */
+export const POST_TITLE = 'h1.wp-block-post-title';
+
+/**
+ * Admin URL for the classic edit screen of a post.
+ *
+ * @param id     Post id.
+ * @param action Value of the `action` query arg.
+ */
+export function editUrl( id: number, action = 'edit' ): string {
+	return `/wp-admin/post.php?post=${ id }&action=${ action }`;
+}
+
+/**
+ * Query string for the post list table, filtered to a status when given.
+ *
+ * @param options.postType   Post type slug. Defaults to `post`.
+ * @param options.postStatus Optional status filter (e.g. the archived slug).
+ * @param options
+ */
+export function postListQuery(
+	options: {
+		postType?: string;
+		postStatus?: string;
+	} = {}
+): string {
+	const { postType = 'post', postStatus } = options;
+	const params = new URLSearchParams( { post_type: postType } );
+
+	if ( postStatus ) {
+		params.set( 'post_status', postStatus );
+	}
+
+	return params.toString();
+}
+
+/**
+ * Every admin notice container on the screen.
+ *
+ * `wp_admin_notice()` is called with `id => message`, so the container id is
+ * the stable hook regardless of the notice classes WordPress adds around it.
+ *
+ * More than one can be present: core's own bulk-message block on `edit.php`
+ * also renders `id="message"` whenever it recognises a counter in the URL
+ * (`locked` is shared vocabulary), so callers should reach for
+ * {@link noticeWith} rather than asserting on this locator directly.
+ *
+ * @param page Page under test.
+ */
+export function noticeLocator( page: Page ): Locator {
+	return page.locator( '#message' );
+}
+
+/**
+ * The admin notice containing the given text.
+ *
+ * @param page Page under test.
+ * @param text Substring or pattern the notice must contain.
+ */
+export function noticeWith( page: Page, text: string | RegExp ): Locator {
+	return noticeLocator( page ).filter( { hasText: text } );
+}
+
+/**
+ * A single row of the list table.
+ *
+ * @param page Page under test.
+ * @param id   Post id.
+ */
+export function rowLocator( page: Page, id: number ): Locator {
+	return page.locator( `#post-${ id }` );
+}
+
+/**
+ * A row action link inside a post's row.
+ *
+ * @param page   Page under test.
+ * @param id     Post id.
+ * @param action Row action key (`archive`, `unarchive`, `edit`, `view`, …).
+ */
+export function rowActionLocator(
+	page: Page,
+	id: number,
+	action: string
+): Locator {
+	return rowLocator( page, id ).locator( `.row-actions .${ action } a` );
+}
+
+/**
+ * The bulk-select checkbox inside a post's row.
+ *
+ * Core names every row's checkbox `post[]`; scoping to the row (rather than a
+ * page-wide `input[name="post[]"]` selector) is what makes the locator
+ * resolve to exactly one element per post id.
+ *
+ * @param page Page under test.
+ * @param id   Post id.
+ */
+export function rowCheckboxLocator( page: Page, id: number ): Locator {
+	return rowLocator( page, id ).locator( 'input[name="post[]"]' );
+}
+
+/**
+ * Tick the bulk-action checkbox for each of the given posts.
+ *
+ * @param page Page under test.
+ * @param ids  Post ids to select.
+ */
+export async function selectRows( page: Page, ids: number[] ): Promise< void > {
+	for ( const id of ids ) {
+		await rowCheckboxLocator( page, id ).check();
+	}
+}
+
+/**
+ * Choose a bulk action, apply it, and return the result counters.
+ *
+ * The counters come from the `Location` header of the redirect the bulk
+ * handler produced, NOT from `page.url()`: `wp_removable_query_args()`
+ * (wp-includes/functions.php) lists `ids`, `locked` and `skipped`, and the
+ * admin strips every listed argument out of the visible URL with
+ * `history.replaceState()` once the page has rendered. The redirect target is
+ * what `Admin\BulkActionResult::apply_to_url()` actually composed, so it is the
+ * contract worth pinning — and the only place the stripped counters can still
+ * be observed.
+ *
+ * @param page   Page under test.
+ * @param action Bulk action value (`archive` / `unarchive`).
+ * @return Query args of the redirect the handler returned.
+ */
+export async function applyBulkAction(
+	page: Page,
+	action: string
+): Promise< URLSearchParams > {
+	await page.locator( '#bulk-action-selector-top' ).selectOption( action );
+
+	const [ redirect ] = await Promise.all( [
+		page.waitForResponse(
+			( response ) =>
+				'document' === response.request().resourceType() &&
+				response.status() >= 300 &&
+				response.status() < 400
+		),
+		page.waitForURL( /edit\.php/ ),
+		page.locator( '#doaction' ).click(),
+	] );
+
+	const location = redirect.headers().location;
+
+	if ( ! location ) {
+		throw new Error(
+			'The bulk action redirect carried no Location header.'
+		);
+	}
+
+	return new URL( location, page.url() ).searchParams;
+}
+
+/**
+ * Read the `bulk-posts` nonce out of the rendered list table form.
+ *
+ * Bulk actions on `edit.php` submit over GET, so a spec can compose a request
+ * WordPress accepts — which is the only way to feed the handler an id that has
+ * no checkbox on screen (a deleted post, or an archived post on a view that
+ * does not offer the Archive action).
+ *
+ * @param page Page under test.
+ */
+export async function readBulkNonce( page: Page ): Promise< string > {
+	const nonce = await page
+		.locator( '#posts-filter input[name="_wpnonce"]' )
+		.first()
+		.inputValue();
+
+	if ( ! nonce ) {
+		throw new Error( 'Could not read the bulk-posts nonce from edit.php.' );
+	}
+
+	return nonce;
+}

--- a/tests/e2e/config/auth.setup.ts
+++ b/tests/e2e/config/auth.setup.ts
@@ -1,0 +1,97 @@
+/**
+ * External dependencies
+ */
+import { test as setup, expect } from '@playwright/test';
+import { RequestUtils } from '@wordpress/e2e-test-utils-playwright';
+
+/**
+ * Internal dependencies
+ */
+import { ADMIN_STORAGE_STATE, ROLE_USERS, storageStatePath } from './roles';
+import type { Role } from './roles';
+
+interface UserRecord {
+	username?: string;
+}
+
+/**
+ * Whether a REST failure means "that login is already taken".
+ *
+ * `RequestUtils.rest()` throws the parsed error body, so the WordPress error
+ * code is on the thrown value.
+ *
+ * @param error Value thrown by a REST call.
+ */
+function isExistingUserError( error: unknown ): boolean {
+	return (
+		typeof error === 'object' &&
+		error !== null &&
+		( error as { code?: string } ).code === 'existing_user_login'
+	);
+}
+
+/**
+ * Create the non-admin role users and persist a signed-in browser state for each.
+ *
+ * Runs as a Playwright setup project that every browser project depends on, so
+ * a spec can switch identity with
+ * `test.use( { storageState: storageStatePath( 'editor' ) } )` without doing its
+ * own login. The admin state is written earlier, by `global-setup.ts`.
+ *
+ * Idempotent: users left behind by a previous run are reused, and their storage
+ * state is refreshed on every run so the cookies are never stale.
+ */
+setup( 'create role users and store their authenticated state', async ( {
+	baseURL,
+} ) => {
+	const admin = await RequestUtils.setup( {
+		baseURL,
+		storageStatePath: ADMIN_STORAGE_STATE,
+	} );
+	await admin.setupRest();
+
+	// `search` keeps our three logins on the first page no matter how many
+	// users a spec has left behind.
+	const existingUsers: UserRecord[] = await admin.rest( {
+		path: '/wp/v2/users',
+		params: { per_page: 100, context: 'edit', search: 'aps_' },
+	} );
+	const existingLogins = new Set(
+		existingUsers.map( ( user ) => user.username )
+	);
+
+	for ( const [ role, user ] of Object.entries( ROLE_USERS ) ) {
+		if ( ! existingLogins.has( user.username ) ) {
+			try {
+				await admin.createUser( {
+					username: user.username,
+					email: user.email,
+					password: user.password,
+					roles: [ role ],
+				} );
+			} catch ( error ) {
+				// The user exists but the listing missed it — carry on and
+				// refresh its storage state below. Anything else is real.
+				if ( ! isExistingUserError( error ) ) {
+					throw error;
+				}
+			}
+		}
+
+		const roleUtils = await RequestUtils.setup( {
+			baseURL,
+			user: { username: user.username, password: user.password },
+			storageStatePath: storageStatePath( role as Role ),
+		} );
+
+		const storageState = await roleUtils.setupRest();
+
+		// A usable state has session cookies; anything else means the login
+		// silently failed and every spec using this role would be misleading.
+		expect( storageState.cookies.length ).toBeGreaterThan( 0 );
+
+		await roleUtils.request.dispose();
+	}
+
+	await admin.request.dispose();
+} );

--- a/tests/e2e/config/fixtures.ts
+++ b/tests/e2e/config/fixtures.ts
@@ -1,0 +1,109 @@
+/**
+ * Toggles for the mu-plugin fixtures mapped into `wp-content/mu-plugins/`.
+ *
+ * Every fixture registers its hooks unconditionally and stays inert until its
+ * option is switched on, so a spec that does not opt in sees stock plugin
+ * behaviour. Each toggle is a registered setting with `show_in_rest`, so it can
+ * be flipped over `PUT /wp/v2/settings` — one request instead of a WP-CLI round
+ * trip.
+ *
+ * Only ever flip these on the tests instance (:8889); the same files are mapped
+ * into the :8888 dev site and a toggle left on there survives until it is
+ * deleted. `resetFixtures()` in an `afterEach`/`afterAll` is not optional.
+ *
+ * @see tests/e2e/fixtures/
+ */
+
+/**
+ * External dependencies
+ */
+import type { RequestUtils } from '@wordpress/e2e-test-utils-playwright';
+
+/**
+ * Option name of each fixture toggle, keyed by a readable alias.
+ */
+export const FIXTURE_TOGGLES = {
+	/** `aps_default_archive|unarchive_capability` -> `manage_options`. */
+	capFilter: 'aps_test_cap_filter_enabled',
+	/** `aps_default_read_capability` -> `manage_options`. Independent of `capFilter`. */
+	readCapFilter: 'aps_test_read_cap_filter_enabled',
+	/** `aps_archivable_statuses` -> `['publish']`. */
+	restrictStatuses: 'aps_test_restrict_statuses_enabled',
+	/** `aps_title_label` / `_before` / `aps_title_separator` overrides. */
+	titleFilters: 'aps_test_title_filters_enabled',
+	/** Force the classic editor and trip `aps_is_classic_editor`. */
+	classicEditor: 'aps_test_classic_editor_enabled',
+	/** Deny the archive/unarchive capability for one post id (0 = off). */
+	deniedPostId: 'aps_test_denied_post_id',
+	/** Publish archived content: `aps_status_arg_public|private|exclude_from_search`. */
+	publicArchive: 'aps_test_public_archive_enabled',
+	/** `aps_enable_archive_meta` -> false; no archive meta is ever written. */
+	disableArchiveMeta: 'aps_test_disable_archive_meta_enabled',
+} as const;
+
+export type FixtureToggle =
+	( typeof FIXTURE_TOGGLES )[ keyof typeof FIXTURE_TOGGLES ];
+
+/**
+ * Value each toggle returns to when a spec is done with it.
+ */
+const TOGGLE_OFF: Record< FixtureToggle, boolean | number > = {
+	[ FIXTURE_TOGGLES.capFilter ]: false,
+	[ FIXTURE_TOGGLES.readCapFilter ]: false,
+	[ FIXTURE_TOGGLES.restrictStatuses ]: false,
+	[ FIXTURE_TOGGLES.titleFilters ]: false,
+	[ FIXTURE_TOGGLES.classicEditor ]: false,
+	[ FIXTURE_TOGGLES.deniedPostId ]: 0,
+	[ FIXTURE_TOGGLES.publicArchive ]: false,
+	[ FIXTURE_TOGGLES.disableArchiveMeta ]: false,
+};
+
+/**
+ * Label the title fixture writes when it is switched on.
+ *
+ * @see tests/e2e/fixtures/aps-title-filters.php — `APS_TEST_TITLE_LABEL`.
+ */
+export const FIXTURE_TITLE_LABEL = 'Retired';
+
+/**
+ * Separator the title fixture writes when it is switched on.
+ *
+ * @see tests/e2e/fixtures/aps-title-filters.php — `APS_TEST_TITLE_SEPARATOR`.
+ */
+export const FIXTURE_TITLE_SEPARATOR = ' :: ';
+
+/**
+ * Switch one or more fixture toggles.
+ *
+ * @param requestUtils Admin request utils.
+ * @param toggles      Map of option name to value.
+ */
+export async function setFixtures(
+	requestUtils: RequestUtils,
+	toggles: Partial< Record< FixtureToggle, boolean | number > >
+): Promise< void > {
+	await requestUtils.rest( {
+		method: 'PUT',
+		path: '/wp/v2/settings',
+		data: toggles,
+	} );
+}
+
+/**
+ * Switch the named toggles back off.
+ *
+ * @param requestUtils Admin request utils.
+ * @param toggles      Toggles to reset. Defaults to every known toggle.
+ */
+export async function resetFixtures(
+	requestUtils: RequestUtils,
+	toggles: FixtureToggle[] = Object.values( FIXTURE_TOGGLES )
+): Promise< void > {
+	const payload: Partial< Record< FixtureToggle, boolean | number > > = {};
+
+	for ( const toggle of toggles ) {
+		payload[ toggle ] = TOGGLE_OFF[ toggle ];
+	}
+
+	await setFixtures( requestUtils, payload );
+}

--- a/tests/e2e/config/global-setup.ts
+++ b/tests/e2e/config/global-setup.ts
@@ -1,0 +1,125 @@
+/**
+ * External dependencies
+ */
+import { request } from '@playwright/test';
+import type { FullConfig } from '@playwright/test';
+import { RequestUtils } from '@wordpress/e2e-test-utils-playwright';
+
+/**
+ * Internal dependencies
+ */
+import { resetFixtures } from './fixtures';
+import {
+	ADMIN_STORAGE_STATE,
+	ARCHIVED_STATUS_SLUG,
+	PLUGIN_SLUG,
+} from './roles';
+import { POST_TYPES, resetPluginSettings } from './seed';
+
+/**
+ * Upper bound on sweep iterations, so a delete that never takes effect fails
+ * loudly instead of hanging the whole run.
+ */
+const MAX_SWEEP_PAGES = 50;
+
+/**
+ * Force-delete every post of a type that carries the archived status.
+ *
+ * `deleteAllPosts()` / `deleteAllPages()` upstream hardcode the core status
+ * list (`publish,future,draft,pending,private,trash`), which never includes the
+ * status this plugin owns — so archived content survives them and leaks between
+ * runs. Paginates rather than assuming a single 100-item page.
+ *
+ * @param requestUtils Authenticated admin request utils.
+ * @param postType     REST base of the post type to sweep (see {@link POST_TYPES}).
+ */
+async function deleteAllArchived(
+	requestUtils: RequestUtils,
+	postType: string
+): Promise< void > {
+	for ( let page = 0; page < MAX_SWEEP_PAGES; page++ ) {
+		const archived: Array< { id: number } > = await requestUtils.rest( {
+			path: `/wp/v2/${ postType }`,
+			params: {
+				status: ARCHIVED_STATUS_SLUG,
+				per_page: 100,
+				context: 'edit',
+			},
+		} );
+
+		if ( ! archived.length ) {
+			return;
+		}
+
+		await Promise.all(
+			archived.map( ( post ) =>
+				requestUtils.rest( {
+					method: 'DELETE',
+					path: `/wp/v2/${ postType }/${ post.id }`,
+					params: { force: true },
+				} )
+			)
+		);
+	}
+
+	throw new Error(
+		`Failed to clear "${ ARCHIVED_STATUS_SLUG }" ${ postType } after ${ MAX_SWEEP_PAGES } passes.`
+	);
+}
+
+/**
+ * Prepare the wp-env test site once, before any project runs.
+ *
+ * Signs in as the wp-env admin and persists the authenticated state so the
+ * `auth` setup project and every spec have a session to start from, makes sure
+ * the plugin under test is active, clears posts, pages and the CPT fixture's
+ * content — including the archived items the upstream helpers cannot see —
+ * and resets the mutable options the suite depends on, so specs begin from a
+ * known-empty content set and stock plugin/fixture behaviour.
+ *
+ * The option reset matters because a run that dies before a spec's `afterEach`
+ * strands state in the database: a leftover `aps_settings` with
+ * `is_read_only => false` silently un-blocks the editor guard and fails every
+ * read-only assertion in the next run, and a leftover `aps_test_*` toggle
+ * leaves a fixture filter hooked for specs that never opted into it. Both
+ * present as code failures with no hint that state is the cause.
+ *
+ * @param config Resolved Playwright config.
+ */
+async function globalSetup( config: FullConfig ): Promise< void > {
+	const { baseURL } = config.projects[ 0 ].use;
+
+	const requestContext = await request.newContext( { baseURL } );
+	const requestUtils = new RequestUtils( requestContext, {
+		baseURL,
+		storageStatePath: ADMIN_STORAGE_STATE,
+	} );
+
+	// Authenticate and write the admin storage state to disk.
+	await requestUtils.setupRest();
+
+	// The plugin under test must be active for every spec — and it has to be
+	// active before the sweep below, since the archived status only exists
+	// while the plugin is running.
+	await requestUtils.activatePlugin( PLUGIN_SLUG );
+
+	// Start from a clean content set. `deleteAllPosts()` / `deleteAllPages()`
+	// are upstream helpers with no equivalent for the `aps_book` fixture post
+	// type (tests/e2e/fixtures/aps-cpt.php), so the archived-content sweep
+	// below runs for every post type under test, `aps_book` included — an
+	// archived post is otherwise invisible to both upstream helpers regardless
+	// of type, per `deleteAllArchived()`'s own docblock.
+	await requestUtils.deleteAllPosts();
+	await requestUtils.deleteAllPages();
+	for ( const { restBase } of POST_TYPES ) {
+		await deleteAllArchived( requestUtils, restBase );
+	}
+
+	// Start from stock plugin settings and every fixture toggle off.
+	await resetPluginSettings( requestUtils );
+	await resetFixtures( requestUtils );
+
+	await requestContext.dispose();
+}
+
+export default globalSetup;

--- a/tests/e2e/config/roles.ts
+++ b/tests/e2e/config/roles.ts
@@ -1,0 +1,89 @@
+/**
+ * External dependencies
+ */
+import path from 'node:path';
+
+/**
+ * Directory holding the authenticated browser storage state for each role.
+ *
+ * Written by `auth.setup.ts` (non-admin roles) and `global-setup.ts` (admin),
+ * consumed by `playwright.config.ts` and by specs via
+ * `test.use( { storageState: storageStatePath( 'editor' ) } )`.
+ *
+ * Git-ignored: the files hold live session cookies.
+ */
+export const AUTH_DIR = path.join( __dirname, '..', '..', '..', 'playwright', '.auth' );
+
+/**
+ * Roles the harness keeps a signed-in browser state for.
+ *
+ * `admin` already exists in a stock wp-env install; the rest are created by
+ * `auth.setup.ts`.
+ */
+export const ROLES = [ 'administrator', 'editor', 'author', 'subscriber' ] as const;
+
+export type Role = ( typeof ROLES )[ number ];
+
+/**
+ * Non-admin users created by `auth.setup.ts`, keyed by role.
+ *
+ * Passwords are fixed so the state can be regenerated deterministically; this
+ * is a throwaway local environment.
+ */
+export const ROLE_USERS: Record<
+	Exclude< Role, 'administrator' >,
+	{ username: string; email: string; password: string }
+> = {
+	editor: {
+		username: 'aps_editor',
+		email: 'aps_editor@example.com',
+		password: 'aps-editor-password',
+	},
+	author: {
+		username: 'aps_author',
+		email: 'aps_author@example.com',
+		password: 'aps-author-password',
+	},
+	subscriber: {
+		username: 'aps_subscriber',
+		email: 'aps_subscriber@example.com',
+		password: 'aps-subscriber-password',
+	},
+};
+
+/**
+ * Absolute path to the stored authentication state for a role.
+ *
+ * @param role Role to resolve the storage state for.
+ */
+export function storageStatePath( role: Role ): string {
+	return path.join( AUTH_DIR, `${ role }.json` );
+}
+
+/**
+ * Storage state used by every project unless a spec opts into another role.
+ */
+export const ADMIN_STORAGE_STATE = storageStatePath( 'administrator' );
+
+/**
+ * Slug of the plugin under test, as `RequestUtils.activatePlugin()` keys it
+ * (kebab-cased plugin name from `/wp/v2/plugins`).
+ */
+export const PLUGIN_SLUG = 'archived-post-status';
+
+/**
+ * Default slug of the archived post status.
+ *
+ * @see src/Status/PostStatusValue.php — `case Slug = 'archive'`, filterable via
+ * `aps_post_status_slug`. Declared once here so the global setup sweep and the
+ * specs cannot drift apart.
+ */
+export const ARCHIVED_STATUS_SLUG = 'archive';
+
+/**
+ * Default label of the archived post status.
+ *
+ * @see src/Status/PostStatusValue.php — `case Label = 'Archived'`, filterable
+ * via `aps_archived_label_string`.
+ */
+export const ARCHIVED_STATUS_LABEL = 'Archived';

--- a/tests/e2e/config/seed.ts
+++ b/tests/e2e/config/seed.ts
@@ -1,0 +1,337 @@
+/**
+ * Content seeding + inspection helpers shared by every spec.
+ *
+ * Everything here goes through the admin-authenticated `requestUtils` fixture,
+ * so a spec can seed state regardless of which role its browser context is
+ * signed in as. Archive transitions route through the `aps-test/v1` mu-plugin
+ * fixture, which calls the plugin's own `aps_archive_post()` /
+ * `aps_unarchive_post()` — the seeded state is produced by the real code path,
+ * not by a raw status write.
+ *
+ * @see tests/e2e/fixtures/aps-test-api.php
+ */
+
+/**
+ * External dependencies
+ */
+import type { RequestUtils } from '@wordpress/e2e-test-utils-playwright';
+
+/**
+ * Archive-relevant state of a post, as reported by the fixture's read route.
+ */
+export interface PostState {
+	id: number;
+	post_status: string;
+	comment_status: string;
+	ping_status: string;
+	post_title: string;
+	link: string;
+	meta: {
+		previous_status: string;
+		archive_date: number;
+		archive_user: number;
+		comment_status: string;
+		ping_status: string;
+	};
+}
+
+/**
+ * A post seeded by {@link seedPost}.
+ */
+export interface SeededPost {
+	id: number;
+	title: string;
+	link: string;
+}
+
+/**
+ * One post type the suite runs against.
+ */
+export interface PostTypeUnderTest {
+	/** Short alias used in test titles/describe blocks. */
+	key: 'post' | 'page' | 'book';
+	/** REST base — the `/wp/v2/<restBase>` path segment `seedPost`/`deletePosts` use. */
+	restBase: 'posts' | 'pages' | 'aps_book';
+	/** `post_type` query arg for the post-list screen (`edit.php`, see `postListQuery()` in `./admin`). */
+	queryArg: 'post' | 'page' | 'aps_book';
+	/** Human label for test titles, e.g. `` `${ label } archive roundtrip` ``. */
+	label: string;
+}
+
+/**
+ * Every post type the suite runs against.
+ *
+ * `post` and `page` are core's own default-`capability_type` types. `book`
+ * (post type slug `aps_book`) is the e2e fixture's custom-`capability_type`
+ * type, whose primitives are `edit_books` / `edit_others_books` rather than
+ * `edit_posts` / `edit_others_posts`. A spec that iterates this table
+ * exercises `Archive\ArchiveCapability` / `Archive\ViewCapability`'s
+ * post-type-primitive resolution against a primitive set that actually
+ * differs from `post`'s, rather than only against types that happen to share
+ * it.
+ *
+ * `restBase` and `queryArg` differ for the core types (REST uses the plural
+ * `posts` / `pages`; the query arg uses the singular `post` / `page`) but are
+ * identical for `book`, which the fixture registers with an explicit
+ * `rest_base` equal to its slug.
+ *
+ * A plain array rather than a keyed lookup: every current use is "run this
+ * assertion for each post type", so a `for…of` is the whole idiom.
+ *
+ * @see tests/e2e/fixtures/aps-cpt.php
+ */
+export const POST_TYPES: readonly PostTypeUnderTest[] = [
+	{ key: 'post', restBase: 'posts', queryArg: 'post', label: 'Post' },
+	{ key: 'page', restBase: 'pages', queryArg: 'page', label: 'Page' },
+	{ key: 'book', restBase: 'aps_book', queryArg: 'aps_book', label: 'Book' },
+];
+
+export interface SeedPayload {
+	title: string;
+	status?: string;
+	content?: string;
+	comment_status?: 'open' | 'closed';
+	ping_status?: 'open' | 'closed';
+	author?: number;
+	type?: PostTypeUnderTest[ 'restBase' ];
+}
+
+let titleCounter = 0;
+
+/**
+ * Build a title that is unique across specs, runs and workers.
+ *
+ * Specs must be independently re-runnable; unique titles keep slug collisions
+ * (`my-post-2`) and cross-spec locator matches from ever happening.
+ *
+ * @param prefix Human-readable prefix, usually the spec name.
+ */
+export function uniqueTitle( prefix: string ): string {
+	titleCounter += 1;
+
+	return `${ prefix } ${ Date.now().toString( 36 ) }-${ titleCounter }`;
+}
+
+/**
+ * Create a post over the core REST API, for any post type under test.
+ *
+ * @param requestUtils Admin request utils.
+ * @param payload      Post attributes; `type` accepts any {@link POST_TYPES} REST base.
+ */
+export async function seedPost(
+	requestUtils: RequestUtils,
+	payload: SeedPayload
+): Promise< SeededPost > {
+	const { type = 'posts', ...data } = payload;
+
+	const post = await requestUtils.rest< { id: number; link: string } >( {
+		method: 'POST',
+		path: `/wp/v2/${ type }`,
+		data: { status: 'draft', ...data },
+	} );
+
+	return { id: post.id, title: payload.title, link: post.link };
+}
+
+/**
+ * Force-delete posts, ignoring ids that are already gone.
+ *
+ * Used from `afterEach`/`afterAll` so every spec leaves the site as it found
+ * it. Failures are swallowed on purpose: a spec that deleted a post as part of
+ * its assertions must still be able to run its own teardown.
+ *
+ * @param requestUtils Admin request utils.
+ * @param ids          Post ids to remove.
+ * @param type         REST base of the post type (see {@link POST_TYPES}). Defaults to `posts`.
+ */
+export async function deletePosts(
+	requestUtils: RequestUtils,
+	ids: number[],
+	type: PostTypeUnderTest[ 'restBase' ] = 'posts'
+): Promise< void > {
+	await Promise.all(
+		ids.map( async ( id ) => {
+			try {
+				await requestUtils.rest( {
+					method: 'DELETE',
+					path: `/wp/v2/${ type }/${ id }`,
+					params: { force: true },
+				} );
+			} catch {
+				// Already deleted — teardown stays best-effort.
+			}
+		} )
+	);
+}
+
+/**
+ * Archive a post through `aps_archive_post()`.
+ *
+ * @param requestUtils Admin request utils.
+ * @param id           Post id.
+ * @return The post's state after the transition.
+ */
+export async function archivePost(
+	requestUtils: RequestUtils,
+	id: number
+): Promise< PostState > {
+	return requestUtils.rest< PostState >( {
+		method: 'POST',
+		path: `/aps-test/v1/archive/${ id }`,
+	} );
+}
+
+/**
+ * Unarchive a post through `aps_unarchive_post()`.
+ *
+ * @param requestUtils Admin request utils.
+ * @param id           Post id.
+ * @return The post's state after the transition.
+ */
+export async function unarchivePost(
+	requestUtils: RequestUtils,
+	id: number
+): Promise< PostState > {
+	return requestUtils.rest< PostState >( {
+		method: 'POST',
+		path: `/aps-test/v1/unarchive/${ id }`,
+	} );
+}
+
+/**
+ * Read a post's archive-relevant state.
+ *
+ * Preferred over `/wp/v2/posts/<id>` because it also returns the archive meta
+ * keys, which the core controller does not expose.
+ *
+ * @param requestUtils Admin request utils.
+ * @param id           Post id.
+ */
+export async function postState(
+	requestUtils: RequestUtils,
+	id: number
+): Promise< PostState > {
+	return requestUtils.rest< PostState >( {
+		method: 'GET',
+		path: `/aps-test/v1/post/${ id }`,
+	} );
+}
+
+/**
+ * Set a post's status with a bare `wp_update_post()` call — no plugin API.
+ *
+ * The bypass path `Status\PostStatusGuard` exists to correct.
+ *
+ * @param requestUtils Admin request utils.
+ * @param id           Post id.
+ * @param data         Status fields to write verbatim.
+ */
+export async function rawStatusUpdate(
+	requestUtils: RequestUtils,
+	id: number,
+	data: {
+		post_status: string;
+		comment_status: 'open' | 'closed';
+		ping_status: 'open' | 'closed';
+	}
+): Promise< PostState > {
+	return requestUtils.rest< PostState >( {
+		method: 'POST',
+		path: `/aps-test/v1/post/${ id }/raw-status`,
+		data,
+	} );
+}
+
+/**
+ * Hold (or release) the post-edit lock on behalf of another user.
+ *
+ * @param requestUtils Admin request utils.
+ * @param id           Post id.
+ * @param userId       User holding the lock; 0 releases it.
+ */
+export async function lockPost(
+	requestUtils: RequestUtils,
+	id: number,
+	userId: number
+): Promise< void > {
+	await requestUtils.rest( {
+		method: 'POST',
+		path: `/aps-test/v1/post/${ id }/lock`,
+		data: { user_id: userId },
+	} );
+}
+
+/**
+ * Overwrite the stored archive date / user for a post.
+ *
+ * `ArchiveMeta::from_post()` stamps `time()`, so posts archived within the same
+ * second tie. Sort assertions set explicit timestamps instead of sleeping.
+ *
+ * @param requestUtils Admin request utils.
+ * @param id           Post id.
+ * @param meta         Values to write.
+ */
+export async function setArchiveMeta(
+	requestUtils: RequestUtils,
+	id: number,
+	meta: { archive_date?: number; archive_user?: number }
+): Promise< PostState > {
+	return requestUtils.rest< PostState >( {
+		method: 'POST',
+		path: `/aps-test/v1/post/${ id }/archive-meta`,
+		data: meta,
+	} );
+}
+
+/**
+ * Write the plugin's `aps_settings` option from outside `Settings\Store`.
+ *
+ * @param requestUtils Admin request utils.
+ * @param isReadOnly   Value for the `is_read_only` setting.
+ */
+export async function setPluginSettings(
+	requestUtils: RequestUtils,
+	isReadOnly: boolean
+): Promise< { is_read_only: boolean } > {
+	return requestUtils.rest( {
+		method: 'POST',
+		path: '/aps-test/v1/settings',
+		data: { is_read_only: isReadOnly },
+	} );
+}
+
+/**
+ * Delete the plugin's `aps_settings` option, restoring stock defaults.
+ *
+ * @param requestUtils Admin request utils.
+ */
+export async function resetPluginSettings(
+	requestUtils: RequestUtils
+): Promise< void > {
+	await requestUtils.rest( {
+		method: 'POST',
+		path: '/aps-test/v1/settings',
+		data: { reset: true },
+	} );
+}
+
+/**
+ * Resolve the user ids of the role logins created by `auth.setup.ts`.
+ *
+ * @param requestUtils Admin request utils.
+ * @return Map of `user_login` to user id.
+ */
+export async function roleUserIds(
+	requestUtils: RequestUtils
+): Promise< Record< string, number > > {
+	const users = await requestUtils.rest<
+		Array< { id: number; username: string } >
+	>( {
+		path: '/wp/v2/users',
+		params: { per_page: 100, context: 'edit', search: 'aps_' },
+	} );
+
+	return Object.fromEntries(
+		users.map( ( user ) => [ user.username, user.id ] )
+	);
+}

--- a/tests/e2e/config/strings.ts
+++ b/tests/e2e/config/strings.ts
@@ -1,0 +1,71 @@
+/**
+ * User-facing strings a spec asserts against, fetched from the plugin's own
+ * source instead of duplicated as literals.
+ *
+ * The `aps-test/v1/strings` route (see `tests/e2e/fixtures/aps-test-api.php`)
+ * returns copy read straight from the plugin classes that own it, so a wording
+ * change can't silently desync the suite. Fetched once per run and memoized —
+ * the strings are static for the duration of the suite, so there is no reason
+ * to pay a request per test.
+ *
+ * @see tests/e2e/fixtures/aps-test-api.php
+ */
+
+/**
+ * External dependencies
+ */
+import type { RequestUtils } from '@wordpress/e2e-test-utils-playwright';
+
+/**
+ * Shape of the `aps-test/v1/strings` response.
+ */
+export interface PluginStrings {
+	read_only_message: string;
+	archive_row_action: string;
+	unarchive_row_action: string;
+	archived_column_label: string;
+	system_attribution: string;
+	unknown_attribution: string;
+	attribution_template: string;
+	undo_label: string;
+	archived_notice_one: string;
+	archived_notice_many: string;
+	unarchived_notice_one: string;
+	unarchived_notice_many: string;
+	locked_notice_one: string;
+	denied_notice_one: string;
+	not_found_notice_one: string;
+	wrong_status_notice_one: string;
+}
+
+let cached: PluginStrings | null = null;
+
+/**
+ * Fetch the plugin's user-facing strings, memoized across the suite.
+ *
+ * @param requestUtils Admin request utils.
+ */
+export async function pluginStrings(
+	requestUtils: RequestUtils
+): Promise< PluginStrings > {
+	if ( ! cached ) {
+		const fetched = await requestUtils.rest< PluginStrings >( {
+			path: '/aps-test/v1/strings',
+		} );
+
+		// Guard the single choke point every spec reads through: an empty
+		// value would make a toContainText()-style assertion vacuously true,
+		// so a broken route must throw here rather than pass silently.
+		for ( const [ key, value ] of Object.entries( fetched ) ) {
+			if ( ! value ) {
+				throw new Error(
+					`aps-test/v1/strings returned an empty value for "${ key }".`
+				);
+			}
+		}
+
+		cached = fetched;
+	}
+
+	return cached;
+}

--- a/tests/e2e/config/wp-cli.ts
+++ b/tests/e2e/config/wp-cli.ts
@@ -1,0 +1,94 @@
+/**
+ * WP-CLI bridge for the specs that need genuine command-line semantics.
+ *
+ * Used sparingly. Seeding goes through the `aps-test/v1` REST fixture because a
+ * WP-CLI round trip costs ~1.2s of Docker/Node startup; this helper exists for
+ * the cases where the CLI *is* the thing under test — most importantly
+ * anonymous archiving, where `get_current_user_id()` returns 0 and the archived
+ * column has to fall back to its "system" attribution.
+ *
+ * Always targets the tests instance (:8889), never the dev site.
+ */
+
+/**
+ * External dependencies
+ */
+import { execFile } from 'node:child_process';
+import path from 'node:path';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify( execFile );
+
+/**
+ * Repo root — `wp-env` resolves `.wp-env.json` relative to the process cwd.
+ */
+const REPO_ROOT = path.join( __dirname, '..', '..', '..' );
+
+/**
+ * Local `wp-env` binary. Invoked directly rather than through `npx` to skip
+ * npx's package resolution on every call.
+ */
+const WP_ENV_BIN = path.join( REPO_ROOT, 'node_modules', '.bin', 'wp-env' );
+
+/**
+ * wp-env service running WP-CLI against the tests site.
+ */
+export const CLI_CONTAINER = 'tests-cli';
+
+export interface WpCliResult {
+	exitCode: number;
+	stdout: string;
+	stderr: string;
+}
+
+/**
+ * Run a `wp` command inside the tests container.
+ *
+ * Never throws on a non-zero exit: the exit code is part of what the CLI specs
+ * assert, so it is returned rather than converted into a rejection.
+ *
+ * @param args `wp` arguments, already split (no shell quoting needed).
+ */
+export async function wpCli( args: string[] ): Promise< WpCliResult > {
+	try {
+		const { stdout, stderr } = await execFileAsync(
+			WP_ENV_BIN,
+			[ 'run', CLI_CONTAINER, '--', 'wp', ...args ],
+			{ cwd: REPO_ROOT, maxBuffer: 10 * 1024 * 1024 }
+		);
+
+		return { exitCode: 0, stdout: stdout.trim(), stderr: stderr.trim() };
+	} catch ( error ) {
+		const failure = error as {
+			code?: number;
+			stdout?: string;
+			stderr?: string;
+		};
+
+		return {
+			exitCode: failure.code ?? 1,
+			stdout: ( failure.stdout ?? '' ).trim(),
+			stderr: ( failure.stderr ?? '' ).trim(),
+		};
+	}
+}
+
+/**
+ * Run a command and fail loudly if it did not succeed.
+ *
+ * @param args `wp` arguments.
+ * @return Trimmed stdout.
+ */
+export async function wpCliOk( args: string[] ): Promise< string > {
+	const result = await wpCli( args );
+
+	if ( 0 !== result.exitCode ) {
+		throw new Error(
+			`wp ${ args.join( ' ' ) } exited ${ result.exitCode }\n${
+				result.stderr
+			}`
+		);
+	}
+
+	return result.stdout;
+}

--- a/tests/e2e/fixtures/aps-cap-filter.php
+++ b/tests/e2e/fixtures/aps-cap-filter.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * E2E mu-plugin fixture: require `manage_options` to archive/unarchive, and
+ * (independently) to view archived content.
+ *
+ * TOGGLES: two options, each boolean, default OFF.
+ *
+ *   aps_test_cap_filter_enabled       archive/unarchive -> manage_options
+ *   aps_test_read_cap_filter_enabled  view (read) -> manage_options
+ *
+ *   REST:   PUT /wp-json/wp/v2/settings { "aps_test_cap_filter_enabled": true }
+ *   WP-CLI: wp option update aps_test_cap_filter_enabled 1
+ *           wp option update aps_test_cap_filter_enabled 0
+ *
+ * This file is mapped into `wp-content/mu-plugins/` by `.wp-env.json`, so it
+ * loads on EVERY request in the test environment. The filters are therefore
+ * registered unconditionally but are inert until their option is switched on,
+ * so specs that do not opt in see stock plugin capabilities.
+ *
+ * Behaviour when `aps_test_cap_filter_enabled` is on: `aps_default_archive_capability`
+ * and `aps_default_unarchive_capability` return `manage_options`, which lets specs
+ * verify that
+ *
+ *   - anonymous WP-CLI (no `--user`) bypasses the cap check (WP-CLI elevated
+ *     context, matching `wp post update|delete|create`);
+ *   - authenticated WP-CLI (`--user=<editor>`) is denied for lack of
+ *     `manage_options`;
+ *   - the admin row-action / bulk-action UI path stays correct under the filter.
+ *
+ * Behaviour when `aps_test_read_cap_filter_enabled` is on: `aps_default_read_capability`
+ * returns `manage_options`, independent of the archive/unarchive toggle above.
+ *
+ * Ported from `tests/manual/fixtures/aps-cap-filter.php` (E2E scenarios
+ * A6/A7); the original was retired once this port landed.
+ *
+ * @package ArchivedPostStatus\TestFixtures
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	die;
+}
+
+/**
+ * Whether the archive/unarchive capability-filter fixture is switched on.
+ *
+ * @return bool
+ */
+function aps_test_cap_filter_enabled() {
+	return (bool) get_option( 'aps_test_cap_filter_enabled', false );
+}
+
+/**
+ * Whether the read (view) capability-filter fixture is switched on.
+ *
+ * @return bool
+ */
+function aps_test_read_cap_filter_enabled() {
+	return (bool) get_option( 'aps_test_read_cap_filter_enabled', false );
+}
+
+add_action(
+	'init',
+	function () {
+		register_setting(
+			'options',
+			'aps_test_cap_filter_enabled',
+			array(
+				'type'         => 'boolean',
+				'default'      => false,
+				'show_in_rest' => true,
+				'description'  => 'E2E fixture: require manage_options to archive and unarchive.',
+			)
+		);
+
+		register_setting(
+			'options',
+			'aps_test_read_cap_filter_enabled',
+			array(
+				'type'         => 'boolean',
+				'default'      => false,
+				'show_in_rest' => true,
+				'description'  => 'E2E fixture: require manage_options to view archived content.',
+			)
+		);
+	}
+);
+
+add_filter(
+	'aps_default_archive_capability',
+	function ( $capability ) {
+		return aps_test_cap_filter_enabled() ? 'manage_options' : $capability;
+	}
+);
+
+add_filter(
+	'aps_default_unarchive_capability',
+	function ( $capability ) {
+		return aps_test_cap_filter_enabled() ? 'manage_options' : $capability;
+	}
+);
+
+add_filter(
+	'aps_default_read_capability',
+	function ( $capability ) {
+		return aps_test_read_cap_filter_enabled() ? 'manage_options' : $capability;
+	}
+);

--- a/tests/e2e/fixtures/aps-classic-editor.php
+++ b/tests/e2e/fixtures/aps-classic-editor.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * E2E mu-plugin fixture: render post.php with the classic editor.
+ *
+ * TOGGLE: option `aps_test_classic_editor_enabled` (boolean, default OFF).
+ *
+ *   REST:   PUT /wp-json/wp/v2/settings { "aps_test_classic_editor_enabled": true }
+ *   WP-CLI: wp option update aps_test_classic_editor_enabled 1
+ *           wp option update aps_test_classic_editor_enabled 0
+ *
+ * Two filters, both required, matching the condition the plugin actually
+ * supports ({@see \ArchivedPostStatus\Admin\EditorContext::is_classic_editor()}):
+ *
+ *   1. `use_block_editor_for_post` -> false makes WordPress render
+ *      `edit-form-advanced.php`, which is what fires `post_submitbox_start` and
+ *      therefore renders the plugin's classic Archive link. Without this the
+ *      classic submit box does not exist on the page at all.
+ *   2. `aps_is_classic_editor` -> true is the documented extension point for
+ *      "a third-party plugin disabled the block editor". `EditorContext`'s
+ *      built-in detection only recognises the Classic Editor plugin by file
+ *      path, so a site that disables the block editor by filter has to trip
+ *      this flag. With it set, `PostEditor::enqueue_scripts()` skips the
+ *      block-editor bundle — which the spec asserts, because that bundle
+ *      dereferences `wp.element` / `wp.editPost` and would throw on a classic
+ *      screen.
+ *
+ * Enabling only (1) is the unsupported combination and is deliberately not what
+ * this fixture does.
+ *
+ * @package ArchivedPostStatus\TestFixtures
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	die;
+}
+
+/**
+ * Whether the classic-editor fixture is switched on.
+ *
+ * @return bool
+ */
+function aps_test_classic_editor_enabled() {
+	return (bool) get_option( 'aps_test_classic_editor_enabled', false );
+}
+
+add_action(
+	'init',
+	function () {
+		register_setting(
+			'options',
+			'aps_test_classic_editor_enabled',
+			array(
+				'type'         => 'boolean',
+				'default'      => false,
+				'show_in_rest' => true,
+				'description'  => 'E2E fixture: force the classic editor and trip aps_is_classic_editor.',
+			)
+		);
+	}
+);
+
+add_filter(
+	'use_block_editor_for_post',
+	function ( $use_block_editor ) {
+		return aps_test_classic_editor_enabled() ? false : $use_block_editor;
+	}
+);
+
+add_filter(
+	'aps_is_classic_editor',
+	function ( $is_classic ) {
+		return aps_test_classic_editor_enabled() ? true : $is_classic;
+	}
+);

--- a/tests/e2e/fixtures/aps-cpt-legacy-caps.php
+++ b/tests/e2e/fixtures/aps-cpt-legacy-caps.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * E2E mu-plugin fixture: a custom post type with `map_meta_cap => false`.
+ *
+ * Companion to `aps-cpt.php`, which pins `map_meta_cap => true` deliberately —
+ * see that file's docblock. This fixture is the shape that trap is guarding
+ * against: WordPress defaults `map_meta_cap` to `false` for any
+ * `capability_type` other than `post`/`page`, and when it's false core's
+ * `map_meta_cap()` reassigns the `edit_post` meta cap to the type's own
+ * singular primitive (`$post_type->cap->edit_post`, e.g. `edit_pamphlet`)
+ * BEFORE firing the `map_meta_cap` filter, with no ownership mapping at all.
+ * `PostEditorGuard::deny_editing_archived()` has to match that primitive, not
+ * just the literal 'edit_post', or this shape of post type stays editable via
+ * a direct edit URL while its row actions correctly hide Edit.
+ *
+ * NOT TOGGLE-GATED, for the same reason as `aps-cpt.php`: registering an
+ * additional PUBLIC post type is additive-only. `SupportedPostTypes::all()`
+ * can only ever add this type to the supported list, never reclassify `post`,
+ * `page`, or `aps_book` — and no spec asserts an exact/exhaustive post-type
+ * list, so there's nothing here to protect.
+ *
+ * `capability_type => 'pamphlet'`, distinct from `aps-cpt.php`'s `book`: a
+ * different slug so the two fixtures can coexist without their primitives
+ * colliding.
+ *
+ * Because `map_meta_cap` is false, core checks the SINGULAR primitives
+ * (`edit_pamphlet` / `read_pamphlet` / `delete_pamphlet`) directly, with no
+ * ownership distinction between an author's own post and anyone else's — the
+ * legacy, pre-3.1 behaviour this fixture exists to exercise. The PLURAL
+ * primitives (`edit_pamphlets` / `edit_others_pamphlets` / etc.) are also
+ * granted so `ArchiveCapability` / `ViewCapability`'s `$post_type_object->cap->*`
+ * resolution — which this plugin uses for archive/unarchive/view, deliberately
+ * routed around `edit_post` — still has something to check against.
+ *
+ * None of these primitives exist on any stock role, so this fixture grants
+ * each role what core's `populate_roles()` grants it for `post` (see
+ * `$full_grant` / `$own_content_grant` below). Grants are additive, idempotent,
+ * and under a namespace nothing else checks — they cannot change how a `post`,
+ * `page`, or `aps_book` spec resolves its own primitives.
+ *
+ * @package ArchivedPostStatus\TestFixtures
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	die;
+}
+
+/**
+ * Slug of the fixture's custom post type.
+ */
+define( 'APS_TEST_LEGACY_CPT_SLUG', 'aps_pamphlet' );
+
+add_action(
+	'init',
+	function () {
+		register_post_type(
+			APS_TEST_LEGACY_CPT_SLUG,
+			array(
+				// Minimal labels: nothing in the suite reads this type's admin
+				// UI copy, only its query args and REST responses.
+				'label'           => 'Pamphlets',
+				'public'          => true,
+				'show_in_rest'    => true,
+				'rest_base'       => APS_TEST_LEGACY_CPT_SLUG,
+				'supports'        => array( 'title', 'editor', 'author', 'comments', 'trackbacks', 'custom-fields' ),
+				'capability_type' => 'pamphlet',
+				'map_meta_cap'    => false,
+			)
+		);
+	}
+);
+
+add_action(
+	'init',
+	function () {
+		$full_grant = array(
+			// Plural primitives: ArchiveCapability / ViewCapability's
+			// ownership-aware $post_type_object->cap->* resolution.
+			'edit_pamphlets',
+			'edit_others_pamphlets',
+			'edit_private_pamphlets',
+			'edit_published_pamphlets',
+			'publish_pamphlets',
+			'read_private_pamphlets',
+			'delete_pamphlets',
+			'delete_private_pamphlets',
+			'delete_published_pamphlets',
+			'delete_others_pamphlets',
+			// Singular primitives: what map_meta_cap() checks directly for
+			// edit_post / read_post / delete_post when map_meta_cap is false,
+			// with no ownership mapping.
+			'edit_pamphlet',
+			'read_pamphlet',
+			'delete_pamphlet',
+		);
+
+		$own_content_grant = array(
+			'edit_pamphlets',
+			'edit_published_pamphlets',
+			'publish_pamphlets',
+			'delete_pamphlets',
+			'delete_published_pamphlets',
+			'edit_pamphlet',
+			'read_pamphlet',
+			'delete_pamphlet',
+		);
+
+		$grants = array(
+			'administrator' => $full_grant,
+			'editor'        => $full_grant,
+			'author'        => $own_content_grant,
+			// `subscriber` deliberately receives no grant: it holds none of the
+			// `post`-equivalent primitives on a stock install either, so a
+			// future spec iterating a post-type list over the deny path gets
+			// the same answer for every type without extra fixture work.
+		);
+
+		foreach ( $grants as $role_slug => $caps ) {
+			aps_test_legacy_cpt_grant_role( $role_slug, $caps );
+		}
+	}
+);
+
+/**
+ * Grant a role a set of capabilities, skipping any it already holds.
+ *
+ * `WP_Role::add_cap()` calls `update_option( 'wp_user_roles', ... )`
+ * unconditionally on every invocation; guarding with `has_cap()` first means a
+ * write happens only for a capability a role doesn't already have. Once every
+ * role holds its full grant, later requests write nothing at all, despite this
+ * mu-plugin loading on every request.
+ *
+ * @param string   $role_slug Role to grant.
+ * @param string[] $caps      Capabilities to add.
+ */
+function aps_test_legacy_cpt_grant_role( $role_slug, $caps ) {
+	$role = get_role( $role_slug );
+
+	if ( ! $role ) {
+		return;
+	}
+
+	foreach ( $caps as $cap ) {
+		if ( ! $role->has_cap( $cap ) ) {
+			$role->add_cap( $cap );
+		}
+	}
+}

--- a/tests/e2e/fixtures/aps-cpt.php
+++ b/tests/e2e/fixtures/aps-cpt.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * E2E mu-plugin fixture: a custom post type with its own capability primitives.
+ *
+ * NOT TOGGLE-GATED, unlike most fixtures here: an additional PUBLIC post type
+ * is additive-only. `SupportedPostTypes::all()` can only ever add this type to
+ * the supported list, never reclassify `post` or `page` — and no spec asserts
+ * an exact/exhaustive post-type list, so there's nothing here to protect.
+ *
+ * `capability_type => 'book'`, not the default `post`: the default would
+ * exercise the same `edit_posts` / `edit_others_posts` primitives `post` and
+ * `page` already cover, proving nothing new about `ArchiveCapability` /
+ * `ViewCapability`'s `$post_type_object->cap->*` resolution.
+ *
+ * `map_meta_cap` is explicitly `true`: WordPress defaults this to `true` only
+ * for `capability_type` `post`/`page` and silently `false` otherwise. Drop it
+ * and `edit_post` / `delete_post` degrade to a legacy passthrough instead of
+ * real ownership-aware mapping — a trap for whoever "simplifies" this later.
+ *
+ * None of the ten `book` primitives WordPress derives exist on any stock
+ * role, so this fixture grants each role what core's `populate_roles()`
+ * grants it for `post` (see `$full_grant` / `$own_content_grant` below).
+ * Grants are additive, idempotent, and under a namespace nothing else checks
+ * — they cannot change how a `post` or `page` spec resolves `edit_posts`.
+ *
+ * @package ArchivedPostStatus\TestFixtures
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	die;
+}
+
+/**
+ * Slug of the fixture's custom post type.
+ *
+ * @see tests/e2e/config/seed.ts — the `book` entry of `POST_TYPES` duplicates
+ * this literal; TypeScript cannot import a PHP constant, so keep the two in
+ * sync by hand if this ever changes.
+ */
+define( 'APS_TEST_CPT_SLUG', 'aps_book' );
+
+add_action(
+	'init',
+	function () {
+		register_post_type(
+			APS_TEST_CPT_SLUG,
+			array(
+				// Minimal labels: nothing in the suite reads this type's admin
+				// UI copy, only its query args and REST responses.
+				'label'           => 'Books',
+				'public'          => true,
+				'show_in_rest'    => true,
+				'rest_base'       => APS_TEST_CPT_SLUG,
+				'supports'        => array( 'title', 'editor', 'author', 'comments', 'trackbacks', 'custom-fields' ),
+				'capability_type' => 'book',
+				'map_meta_cap'    => true,
+			)
+		);
+	}
+);
+
+add_action(
+	'init',
+	function () {
+		$full_grant = array(
+			'edit_books',
+			'edit_others_books',
+			'edit_private_books',
+			'edit_published_books',
+			'publish_books',
+			'read_private_books',
+			'delete_books',
+			'delete_private_books',
+			'delete_published_books',
+			'delete_others_books',
+		);
+
+		$own_content_grant = array(
+			'edit_books',
+			'edit_published_books',
+			'publish_books',
+			'delete_books',
+			'delete_published_books',
+		);
+
+		$grants = array(
+			'administrator' => $full_grant,
+			'editor'        => $full_grant,
+			'author'        => $own_content_grant,
+			// `subscriber` deliberately receives no grant: it holds none of the
+			// `post`-equivalent primitives on a stock install either, so a
+			// future spec iterating `POST_TYPES` over the deny path gets the
+			// same answer for every type without extra fixture work.
+		);
+
+		foreach ( $grants as $role_slug => $caps ) {
+			aps_test_cpt_grant_role( $role_slug, $caps );
+		}
+	}
+);
+
+/**
+ * Grant a role a set of capabilities, skipping any it already holds.
+ *
+ * `WP_Role::add_cap()` calls `update_option( 'wp_user_roles', ... )`
+ * unconditionally on every invocation; guarding with `has_cap()` first means a
+ * write happens only for a capability a role doesn't already have. Once every
+ * role holds its full grant, later requests write nothing at all, despite this
+ * mu-plugin loading on every request.
+ *
+ * @param string   $role_slug Role to grant.
+ * @param string[] $caps      Capabilities to add.
+ */
+function aps_test_cpt_grant_role( $role_slug, $caps ) {
+	$role = get_role( $role_slug );
+
+	if ( ! $role ) {
+		return;
+	}
+
+	foreach ( $caps as $cap ) {
+		if ( ! $role->has_cap( $cap ) ) {
+			$role->add_cap( $cap );
+		}
+	}
+}

--- a/tests/e2e/fixtures/aps-deny-post.php
+++ b/tests/e2e/fixtures/aps-deny-post.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * E2E mu-plugin fixture: deny archive/unarchive capability for ONE post id.
+ *
+ * TOGGLE: option `aps_test_denied_post_id` (integer, default 0 = off).
+ *
+ *   REST:   PUT /wp-json/wp/v2/settings { "aps_test_denied_post_id": 123 }
+ *   WP-CLI: wp option update aps_test_denied_post_id 123
+ *           wp option update aps_test_denied_post_id 0
+ *
+ * Why a per-post denial rather than reusing `aps-cap-filter.php`: the bulk
+ * handler runs a screen-level capability gate first
+ * ({@see \ArchivedPostStatus\Admin\BulkActionHandler::handle()} calls the cap
+ * function with no post id) and returns the sendback untouched when it fails.
+ * A blanket cap filter therefore aborts the whole batch and the per-item
+ * `denied` bucket is never reached. Both `aps_default_archive_capability` and
+ * `aps_default_unarchive_capability` receive the post id as their second
+ * argument, so keying on it lets the outer gate pass and exactly one item be
+ * skipped — which is the state the bulk-action notices need to be pinned
+ * against.
+ *
+ * Behaviour when enabled: for the flagged post id only, the required capability
+ * becomes `aps_test_impossible_capability`, a capability no role holds (this is
+ * a single-site install, so there is no super-admin bypass — administrators are
+ * denied too, which keeps the spec on one identity).
+ *
+ * @package ArchivedPostStatus\TestFixtures
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	die;
+}
+
+/**
+ * Post id whose archive/unarchive capability is denied, or 0 when off.
+ *
+ * @return int
+ */
+function aps_test_denied_post_id() {
+	return (int) get_option( 'aps_test_denied_post_id', 0 );
+}
+
+/**
+ * Swap in an unattainable capability for the flagged post.
+ *
+ * @param string|mixed $capability Capability resolved so far.
+ * @param int|mixed    $post_id    Post the check is being made against.
+ * @return string|mixed
+ */
+function aps_test_deny_capability_for_post( $capability, $post_id = 0 ) {
+	$denied = aps_test_denied_post_id();
+
+	if ( $denied && (int) $post_id === $denied ) {
+		return 'aps_test_impossible_capability';
+	}
+
+	return $capability;
+}
+
+add_action(
+	'init',
+	function () {
+		register_setting(
+			'options',
+			'aps_test_denied_post_id',
+			array(
+				'type'         => 'integer',
+				'default'      => 0,
+				'show_in_rest' => true,
+				'description'  => 'E2E fixture: deny archive/unarchive capability for this post id only.',
+			)
+		);
+	}
+);
+
+add_filter( 'aps_default_archive_capability', 'aps_test_deny_capability_for_post', 10, 2 );
+add_filter( 'aps_default_unarchive_capability', 'aps_test_deny_capability_for_post', 10, 2 );

--- a/tests/e2e/fixtures/aps-disable-archive-meta.php
+++ b/tests/e2e/fixtures/aps-disable-archive-meta.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * E2E mu-plugin fixture: force `aps_enable_archive_meta` to false.
+ *
+ * TOGGLE: option `aps_test_disable_archive_meta_enabled` (boolean, default OFF).
+ *
+ *   REST:   PUT /wp-json/wp/v2/settings { "aps_test_disable_archive_meta_enabled": true }
+ *   WP-CLI: wp option update aps_test_disable_archive_meta_enabled 1
+ *           wp option update aps_test_disable_archive_meta_enabled 0
+ *
+ * This file is mapped into `wp-content/mu-plugins/` by `.wp-env.json`, so it
+ * loads on EVERY request in the test environment — including the
+ * `plugins_loaded` request where `Plugin::hookables()` reads
+ * `aps_enable_archive_meta`. The filter below is therefore registered
+ * unconditionally but is inert until the option is switched on, so specs
+ * that do not opt in see stock plugin behaviour (archive meta recorded and
+ * `ArchiveMetaListener` registered as usual).
+ *
+ * Behaviour when enabled: `aps_enable_archive_meta` returns `false`, which
+ * (per `Plugin::hookables()`) skips registering `ArchiveMetaListener`
+ * entirely for the request. Archiving a post then writes no
+ * `_aps_archive_meta_*` postmeta at all, and `ArchiveMeta::for_post()`
+ * returns `null` for it — which is exactly the pre-0.4.0-shaped state
+ * `UnarchiveOperation::resolve_restore_values()`'s legacy branch exists to
+ * handle: unarchiving such a post falls back to `draft`/`closed`/`closed`
+ * rather than reading a snapshot that was never written.
+ *
+ * @package ArchivedPostStatus\TestFixtures
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	die;
+}
+
+/**
+ * Whether the disable-archive-meta fixture is switched on.
+ *
+ * @return bool
+ */
+function aps_test_disable_archive_meta_enabled() {
+	return (bool) get_option( 'aps_test_disable_archive_meta_enabled', false );
+}
+
+add_action(
+	'init',
+	function () {
+		register_setting(
+			'options',
+			'aps_test_disable_archive_meta_enabled',
+			array(
+				'type'         => 'boolean',
+				'default'      => false,
+				'show_in_rest' => true,
+				'description'  => 'E2E fixture: force aps_enable_archive_meta to false.',
+			)
+		);
+	}
+);
+
+add_filter(
+	'aps_enable_archive_meta',
+	function ( $enabled ) {
+		return aps_test_disable_archive_meta_enabled() ? false : $enabled;
+	}
+);

--- a/tests/e2e/fixtures/aps-public-archive.php
+++ b/tests/e2e/fixtures/aps-public-archive.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * E2E mu-plugin fixture: publish archived content to the world.
+ *
+ * TOGGLE: option `aps_test_public_archive_enabled` (boolean, default OFF).
+ *
+ *   REST:   PUT /wp-json/wp/v2/settings { "aps_test_public_archive_enabled": true }
+ *   WP-CLI: wp option update aps_test_public_archive_enabled 1
+ *           wp option update aps_test_public_archive_enabled 0
+ *
+ * This file is mapped into `wp-content/mu-plugins/` by `.wp-env.json`, so it
+ * loads on EVERY request in the test environment. The filters are therefore
+ * registered unconditionally but are inert until the option is switched on, so
+ * specs that do not opt in see stock plugin behaviour.
+ *
+ * Behaviour when enabled: applies the three-filter recipe published in the
+ * plugin's readme for making archived content publicly readable. The
+ * corresponding spec pins that recipe end to end, because it is documented
+ * behaviour that shipped in 0.3.x and a front-end guard added later can
+ * silently override it.
+ *
+ * @package ArchivedPostStatus\TestFixtures
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	die;
+}
+
+/**
+ * Whether the public-archive fixture is switched on.
+ *
+ * @return bool
+ */
+function aps_test_public_archive_enabled() {
+	return (bool) get_option( 'aps_test_public_archive_enabled', false );
+}
+
+add_action(
+	'init',
+	function () {
+		register_setting(
+			'options',
+			'aps_test_public_archive_enabled',
+			array(
+				'type'         => 'boolean',
+				'default'      => false,
+				'show_in_rest' => true,
+				'description'  => 'E2E fixture: make archived content publicly readable.',
+			)
+		);
+	}
+);
+
+foreach ( array( 'aps_status_arg_public', 'aps_status_arg_private', 'aps_status_arg_exclude_from_search' ) as $aps_test_status_arg ) {
+	add_filter(
+		$aps_test_status_arg,
+		function ( $value ) use ( $aps_test_status_arg ) {
+			if ( ! aps_test_public_archive_enabled() ) {
+				return $value;
+			}
+
+			// public => true; private and exclude_from_search => false.
+			return 'aps_status_arg_public' === $aps_test_status_arg;
+		}
+	);
+}

--- a/tests/e2e/fixtures/aps-restrict-statuses.php
+++ b/tests/e2e/fixtures/aps-restrict-statuses.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * E2E mu-plugin fixture: restrict archivable statuses to `publish` only.
+ *
+ * TOGGLE: option `aps_test_restrict_statuses_enabled` (boolean, default OFF).
+ *
+ *   REST:   PUT /wp-json/wp/v2/settings { "aps_test_restrict_statuses_enabled": true }
+ *   WP-CLI: wp option update aps_test_restrict_statuses_enabled 1
+ *           wp option update aps_test_restrict_statuses_enabled 0
+ *
+ * This file is mapped into `wp-content/mu-plugins/` by `.wp-env.json`, so it
+ * loads on EVERY request in the test environment. The filter is therefore
+ * registered unconditionally but is inert until the option is switched on, so
+ * specs that do not opt in see stock plugin behaviour.
+ *
+ * Behaviour when enabled: `aps_archivable_statuses` is narrowed to
+ * `array( 'publish' )`, so archiving a non-published post is rejected.
+ *
+ * Ported from `tests/manual/fixtures/aps-restrict-statuses.php` (E2E scenario
+ * status-restriction checks); the original was retired once this port landed.
+ *
+ * @package ArchivedPostStatus\TestFixtures
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	die;
+}
+
+/**
+ * Whether the restricted-statuses fixture is switched on.
+ *
+ * @return bool
+ */
+function aps_test_restrict_statuses_enabled() {
+	return (bool) get_option( 'aps_test_restrict_statuses_enabled', false );
+}
+
+add_action(
+	'init',
+	function () {
+		register_setting(
+			'options',
+			'aps_test_restrict_statuses_enabled',
+			array(
+				'type'         => 'boolean',
+				'default'      => false,
+				'show_in_rest' => true,
+				'description'  => 'E2E fixture: restrict aps_archivable_statuses to publish only.',
+			)
+		);
+	}
+);
+
+add_filter(
+	'aps_archivable_statuses',
+	function ( $statuses ) {
+		if ( ! aps_test_restrict_statuses_enabled() ) {
+			return $statuses;
+		}
+
+		return array( 'publish' );
+	}
+);

--- a/tests/e2e/fixtures/aps-test-api.php
+++ b/tests/e2e/fixtures/aps-test-api.php
@@ -1,0 +1,319 @@
+<?php
+/**
+ * E2E mu-plugin fixture: seeding + inspection endpoints for the Playwright suite.
+ *
+ * NAMESPACE: `aps-test/v1`. Every route declares
+ * `permission_callback => current_user_can( 'manage_options' )`, so the surface is
+ * unreachable to anonymous or low-privileged requests.
+ *
+ * NOT TOGGLE-GATED, unlike the other fixtures in this directory, and deliberately
+ * so: the toggles exist because those fixtures hook plugin filters and would
+ * therefore change behaviour on every request in the environment. These routes
+ * register nothing on the plugin's own hooks — they are inert until an
+ * authenticated administrator calls them — so a toggle would add per-spec
+ * bookkeeping without removing any risk.
+ *
+ * Why routes instead of `wp-env run tests-cli` for every seed: a WP-CLI round trip
+ * costs ~1.2s of Docker/Node startup, which a twelve-spec suite pays hundreds of
+ * times over. These endpoints call the same public API functions the CLI command
+ * calls (`aps_archive_post()` / `aps_unarchive_post()`), so the seeded state is
+ * produced by the real code path, not by a raw status write. Specs that need
+ * genuine CLI semantics (anonymous archiving with no current user, so
+ * `ArchiveMeta::from_post()` records user 0) still shell out to WP-CLI.
+ *
+ * Routes:
+ *   POST aps-test/v1/archive/<id>          -> aps_archive_post()
+ *   POST aps-test/v1/unarchive/<id>        -> aps_unarchive_post()
+ *   GET  aps-test/v1/post/<id>             -> status + comment/ping status + archive meta
+ *   POST aps-test/v1/post/<id>/raw-status  -> bare wp_update_post(), bypassing the plugin API
+ *   POST aps-test/v1/post/<id>/lock        -> write `_edit_lock` for another user
+ *   POST aps-test/v1/post/<id>/archive-meta-> overwrite archive date/user meta
+ *   POST aps-test/v1/settings              -> external update_option( 'aps_settings' ) write
+ *   GET  aps-test/v1/strings               -> user-facing strings asserted by specs, sourced from plugin code
+ *
+ * @package ArchivedPostStatus\TestFixtures
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	die;
+}
+
+/**
+ * Shared permission callback: administrators only.
+ *
+ * @return bool
+ */
+function aps_test_api_can_manage() {
+	return current_user_can( 'manage_options' );
+}
+
+/**
+ * Describe a post's archive-relevant state.
+ *
+ * Returned by every mutating route as well as the read route so a spec can
+ * assert on the outcome without a second request.
+ *
+ * @param int $post_id Post ID.
+ * @return array<string, mixed>|WP_Error
+ */
+function aps_test_api_describe_post( $post_id ) {
+	$post = get_post( $post_id );
+
+	if ( ! $post ) {
+		return new WP_Error( 'aps_test_no_post', "No post {$post_id}.", array( 'status' => 404 ) );
+	}
+
+	return array(
+		'id'             => $post->ID,
+		'post_status'    => $post->post_status,
+		'comment_status' => $post->comment_status,
+		'ping_status'    => $post->ping_status,
+		'post_title'     => $post->post_title,
+		'link'           => get_permalink( $post ),
+		'meta'           => array(
+			'previous_status' => get_post_meta( $post_id, '_aps_archive_meta_status', true ),
+			'archive_date'    => (int) get_post_meta( $post_id, '_aps_archive_meta_time', true ),
+			'archive_user'    => (int) get_post_meta( $post_id, '_aps_archive_meta_user', true ),
+			'comment_status'  => get_post_meta( $post_id, '_aps_archive_meta_comment_status', true ),
+			'ping_status'     => get_post_meta( $post_id, '_aps_archive_meta_ping_status', true ),
+		),
+	);
+}
+
+add_action(
+	'rest_api_init',
+	function () {
+		$id_args = array(
+			'id' => array(
+				'required'          => true,
+				'validate_callback' => static function ( $value ) {
+					return is_numeric( $value );
+				},
+			),
+		);
+
+		// Archive through the plugin's public API.
+		register_rest_route(
+			'aps-test/v1',
+			'/archive/(?P<id>\d+)',
+			array(
+				'methods'             => 'POST',
+				'permission_callback' => 'aps_test_api_can_manage',
+				'args'                => $id_args,
+				'callback'            => static function ( WP_REST_Request $request ) {
+					$post_id = (int) $request['id'];
+					$result  = aps_archive_post( $post_id );
+
+					if ( ! $result ) {
+						return new WP_Error(
+							'aps_test_archive_failed',
+							"aps_archive_post() returned falsey for {$post_id}.",
+							array( 'status' => 409 )
+						);
+					}
+
+					return rest_ensure_response( aps_test_api_describe_post( $post_id ) );
+				},
+			)
+		);
+
+		// Unarchive through the plugin's public API.
+		register_rest_route(
+			'aps-test/v1',
+			'/unarchive/(?P<id>\d+)',
+			array(
+				'methods'             => 'POST',
+				'permission_callback' => 'aps_test_api_can_manage',
+				'args'                => $id_args,
+				'callback'            => static function ( WP_REST_Request $request ) {
+					$post_id = (int) $request['id'];
+					$result  = aps_unarchive_post( $post_id );
+
+					if ( ! $result ) {
+						return new WP_Error(
+							'aps_test_unarchive_failed',
+							"aps_unarchive_post() returned falsey for {$post_id}.",
+							array( 'status' => 409 )
+						);
+					}
+
+					return rest_ensure_response( aps_test_api_describe_post( $post_id ) );
+				},
+			)
+		);
+
+		// Read archive-relevant state.
+		register_rest_route(
+			'aps-test/v1',
+			'/post/(?P<id>\d+)',
+			array(
+				'methods'             => 'GET',
+				'permission_callback' => 'aps_test_api_can_manage',
+				'args'                => $id_args,
+				'callback'            => static function ( WP_REST_Request $request ) {
+					return rest_ensure_response( aps_test_api_describe_post( (int) $request['id'] ) );
+				},
+			)
+		);
+
+		/*
+		 * Bare wp_update_post() — the "somebody set post_status directly"
+		 * path that PostStatusGuard exists to correct. Deliberately does NOT
+		 * call aps_archive_post().
+		 */
+		register_rest_route(
+			'aps-test/v1',
+			'/post/(?P<id>\d+)/raw-status',
+			array(
+				'methods'             => 'POST',
+				'permission_callback' => 'aps_test_api_can_manage',
+				'args'                => $id_args,
+				'callback'            => static function ( WP_REST_Request $request ) {
+					$post_id = (int) $request['id'];
+
+					wp_update_post(
+						array(
+							'ID'             => $post_id,
+							'post_status'    => (string) $request->get_param( 'post_status' ),
+							'comment_status' => (string) $request->get_param( 'comment_status' ),
+							'ping_status'    => (string) $request->get_param( 'ping_status' ),
+						)
+					);
+
+					clean_post_cache( $post_id );
+
+					return rest_ensure_response( aps_test_api_describe_post( $post_id ) );
+				},
+			)
+		);
+
+		/*
+		 * Write `_edit_lock` on behalf of another user so a spec can exercise
+		 * the bulk-action "locked" skip bucket. The meta key is protected, so
+		 * the core posts controller cannot set it.
+		 */
+		register_rest_route(
+			'aps-test/v1',
+			'/post/(?P<id>\d+)/lock',
+			array(
+				'methods'             => 'POST',
+				'permission_callback' => 'aps_test_api_can_manage',
+				'args'                => $id_args,
+				'callback'            => static function ( WP_REST_Request $request ) {
+					$post_id = (int) $request['id'];
+					$user_id = (int) $request->get_param( 'user_id' );
+
+					if ( $user_id ) {
+						update_post_meta( $post_id, '_edit_lock', time() . ':' . $user_id );
+					} else {
+						delete_post_meta( $post_id, '_edit_lock' );
+					}
+
+					return rest_ensure_response(
+						array(
+							'id'         => $post_id,
+							'_edit_lock' => get_post_meta( $post_id, '_edit_lock', true ),
+						)
+					);
+				},
+			)
+		);
+
+		/*
+		 * Overwrite the archive date/user meta. ArchiveMeta::from_post() stamps
+		 * time(), so two posts archived inside the same second tie — which would
+		 * make a sort assertion non-deterministic. Specs set explicit
+		 * timestamps instead of sleeping.
+		 */
+		register_rest_route(
+			'aps-test/v1',
+			'/post/(?P<id>\d+)/archive-meta',
+			array(
+				'methods'             => 'POST',
+				'permission_callback' => 'aps_test_api_can_manage',
+				'args'                => $id_args,
+				'callback'            => static function ( WP_REST_Request $request ) {
+					$post_id = (int) $request['id'];
+
+					if ( null !== $request->get_param( 'archive_date' ) ) {
+						update_post_meta( $post_id, '_aps_archive_meta_time', (int) $request->get_param( 'archive_date' ) );
+					}
+
+					if ( null !== $request->get_param( 'archive_user' ) ) {
+						update_post_meta( $post_id, '_aps_archive_meta_user', (int) $request->get_param( 'archive_user' ) );
+					}
+
+					return rest_ensure_response( aps_test_api_describe_post( $post_id ) );
+				},
+			)
+		);
+
+		/*
+		 * External write of the plugin's settings option. Uses update_option()
+		 * / delete_option() directly rather than Settings\Store so the spec
+		 * exercises the cache-invalidation hooks wired in Settings\HookAdapter
+		 * (the path an unaware third party would take), not Store's own
+		 * cache priming.
+		 */
+		register_rest_route(
+			'aps-test/v1',
+			'/settings',
+			array(
+				'methods'             => 'POST',
+				'permission_callback' => 'aps_test_api_can_manage',
+				'callback'            => static function ( WP_REST_Request $request ) {
+					if ( $request->get_param( 'reset' ) ) {
+						delete_option( 'aps_settings' );
+					} else {
+						update_option(
+							'aps_settings',
+							array( 'is_read_only' => (bool) $request->get_param( 'is_read_only' ) )
+						);
+					}
+
+					return rest_ensure_response(
+						array(
+							'aps_settings'  => get_option( 'aps_settings', array() ),
+							'is_read_only' => aps_is_read_only(),
+						)
+					);
+				},
+			)
+		);
+
+		// User-facing strings asserted by specs, read straight from the
+		// plugin source so a copy change can't silently desync the suite.
+		register_rest_route(
+			'aps-test/v1',
+			'/strings',
+			array(
+				'methods'             => 'GET',
+				'permission_callback' => 'aps_test_api_can_manage',
+				'callback'            => static function () {
+					$notices = new \ArchivedPostStatus\Admin\NoticeBuilder();
+
+					return rest_ensure_response(
+						array(
+							'read_only_message'       => \ArchivedPostStatus\Admin\PostEditorGuard::read_only_message(),
+							'archive_row_action'      => \ArchivedPostStatus\Admin\RowActionPolicy::archive_label(),
+							'unarchive_row_action'    => \ArchivedPostStatus\Admin\RowActionPolicy::unarchive_label(),
+							'archived_column_label'   => \ArchivedPostStatus\Admin\ArchiveColumn::column_label(),
+							'system_attribution'      => \ArchivedPostStatus\Admin\ArchiveColumn::system_attribution_label(),
+							'unknown_attribution'     => \ArchivedPostStatus\Admin\ArchiveColumn::unknown_attribution_label(),
+							'attribution_template'    => \ArchivedPostStatus\Admin\ArchiveColumn::attribution_template(),
+							'undo_label'              => \ArchivedPostStatus\Admin\NoticeBuilder::undo_label(),
+							'archived_notice_one'     => $notices->build_archive_notice( 1, array(), 'post' ),
+							'archived_notice_many'    => $notices->build_archive_notice( 2, array(), 'post' ),
+							'unarchived_notice_one'   => $notices->build_unarchive_notice( 1, array() ),
+							'unarchived_notice_many'  => $notices->build_unarchive_notice( 2, array() ),
+							'locked_notice_one'       => $notices->format_bucket_notice( 'locked', 1 ),
+							'denied_notice_one'       => $notices->format_bucket_notice( 'denied', 1 ),
+							'not_found_notice_one'    => $notices->format_bucket_notice( 'not_found', 1 ),
+							'wrong_status_notice_one' => $notices->format_bucket_notice( 'wrong_status', 1 ),
+						)
+					);
+				},
+			)
+		);
+	}
+);

--- a/tests/e2e/fixtures/aps-title-filters.php
+++ b/tests/e2e/fixtures/aps-title-filters.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * E2E mu-plugin fixture: override the archived title label, position and separator.
+ *
+ * TOGGLE: option `aps_test_title_filters_enabled` (boolean, default OFF).
+ *
+ *   REST:   PUT /wp-json/wp/v2/settings { "aps_test_title_filters_enabled": true }
+ *   WP-CLI: wp option update aps_test_title_filters_enabled 1
+ *           wp option update aps_test_title_filters_enabled 0
+ *
+ * This file is mapped into `wp-content/mu-plugins/` by `.wp-env.json`, so it
+ * loads on EVERY request in the test environment. The filters are therefore
+ * registered unconditionally but return the incoming value until the option is
+ * switched on, so specs that do not opt in see the stock `Archived: Title`
+ * output.
+ *
+ * Behaviour when enabled ({@see \ArchivedPostStatus\Frontend\ArchiveTitle}):
+ *   - `aps_title_label`        -> 'Retired'
+ *   - `aps_title_label_before` -> false  (label moves after the title)
+ *   - `aps_title_separator`    -> ' :: ' (replaces the ' - ' after-position default)
+ *
+ * so an archived post titled "Foo" renders as "Foo :: Retired". The three
+ * filters are exercised together because the after-position branch reverses the
+ * label/separator pair — asserting the composed string pins the ordering as well
+ * as the individual values.
+ *
+ * @package ArchivedPostStatus\TestFixtures
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	die;
+}
+
+/**
+ * Whether the title-filter fixture is switched on.
+ *
+ * @return bool
+ */
+function aps_test_title_filters_enabled() {
+	return (bool) get_option( 'aps_test_title_filters_enabled', false );
+}
+
+/**
+ * Label used by the fixture when enabled.
+ */
+define( 'APS_TEST_TITLE_LABEL', 'Retired' );
+
+/**
+ * Separator used by the fixture when enabled.
+ */
+define( 'APS_TEST_TITLE_SEPARATOR', ' :: ' );
+
+add_action(
+	'init',
+	function () {
+		register_setting(
+			'options',
+			'aps_test_title_filters_enabled',
+			array(
+				'type'         => 'boolean',
+				'default'      => false,
+				'show_in_rest' => true,
+				'description'  => 'E2E fixture: override aps_title_label / _before / aps_title_separator.',
+			)
+		);
+	}
+);
+
+add_filter(
+	'aps_title_label',
+	function ( $label ) {
+		return aps_test_title_filters_enabled() ? APS_TEST_TITLE_LABEL : $label;
+	}
+);
+
+add_filter(
+	'aps_title_label_before',
+	function ( $before ) {
+		return aps_test_title_filters_enabled() ? false : $before;
+	}
+);
+
+add_filter(
+	'aps_title_separator',
+	function ( $separator ) {
+		return aps_test_title_filters_enabled() ? APS_TEST_TITLE_SEPARATOR : $separator;
+	}
+);

--- a/tests/e2e/specs/editor/archive-unarchive-roundtrip.spec.ts
+++ b/tests/e2e/specs/editor/archive-unarchive-roundtrip.spec.ts
@@ -1,0 +1,224 @@
+/**
+ * Pins the 0.3.12 round-trip contract: unarchiving restores what archiving
+ * captured.
+ *
+ * `Archive\ArchiveMetaListener` snapshots the pre-archive status, comment status
+ * and ping status into post meta; `Archive\UnarchiveOperation` reads that
+ * snapshot back. A post therefore comes out of the archive in the state it went
+ * in — not in a hardcoded default.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { test, expect } from '@wordpress/e2e-test-utils-playwright';
+
+/**
+ * Internal dependencies
+ */
+import { ARCHIVED_STATUS_SLUG } from '../../config/roles';
+import {
+	FIXTURE_TOGGLES,
+	resetFixtures,
+	setFixtures,
+} from '../../config/fixtures';
+import {
+	archivePost,
+	deletePosts,
+	postState,
+	seedPost,
+	unarchivePost,
+	uniqueTitle,
+} from '../../config/seed';
+
+test.describe( 'archive / unarchive round trip', () => {
+	const created: number[] = [];
+
+	test.afterEach( async ( { requestUtils } ) => {
+		await deletePosts( requestUtils, created.splice( 0 ) );
+	} );
+
+	test( 'a draft comes back as a draft', async ( { requestUtils } ) => {
+		const post = await seedPost( requestUtils, {
+			title: uniqueTitle( 'Round trip draft' ),
+			status: 'draft',
+			comment_status: 'closed',
+			ping_status: 'closed',
+		} );
+		created.push( post.id );
+
+		const archived = await archivePost( requestUtils, post.id );
+		expect( archived.post_status ).toBe( ARCHIVED_STATUS_SLUG );
+		expect( archived.meta.previous_status ).toBe( 'draft' );
+
+		const restored = await unarchivePost( requestUtils, post.id );
+
+		expect( restored.post_status ).toBe( 'draft' );
+		expect( restored.comment_status ).toBe( 'closed' );
+		expect( restored.ping_status ).toBe( 'closed' );
+	} );
+
+	test( 'a published post comes back published with discussion re-opened', async ( {
+		requestUtils,
+	} ) => {
+		const post = await seedPost( requestUtils, {
+			title: uniqueTitle( 'Round trip publish' ),
+			status: 'publish',
+			comment_status: 'open',
+			ping_status: 'open',
+		} );
+		created.push( post.id );
+
+		const archived = await archivePost( requestUtils, post.id );
+		expect( archived.post_status ).toBe( ARCHIVED_STATUS_SLUG );
+		expect( archived.comment_status ).toBe( 'closed' );
+		expect( archived.ping_status ).toBe( 'closed' );
+
+		const restored = await unarchivePost( requestUtils, post.id );
+
+		expect( restored.post_status ).toBe( 'publish' );
+		expect( restored.comment_status ).toBe( 'open' );
+		expect( restored.ping_status ).toBe( 'open' );
+	} );
+
+	test( 'a private post comes back private', async ( { requestUtils } ) => {
+		const post = await seedPost( requestUtils, {
+			title: uniqueTitle( 'Round trip private' ),
+			status: 'private',
+			comment_status: 'open',
+			ping_status: 'closed',
+		} );
+		created.push( post.id );
+
+		await archivePost( requestUtils, post.id );
+		const restored = await unarchivePost( requestUtils, post.id );
+
+		expect( restored.post_status ).toBe( 'private' );
+		expect( restored.comment_status ).toBe( 'open' );
+		expect( restored.ping_status ).toBe( 'closed' );
+	} );
+
+	test( 'the archive meta is written on archive and cleared on unarchive', async ( {
+		requestUtils,
+	} ) => {
+		const post = await seedPost( requestUtils, {
+			title: uniqueTitle( 'Round trip meta' ),
+			status: 'publish',
+			comment_status: 'open',
+			ping_status: 'open',
+		} );
+		created.push( post.id );
+
+		const archived = await archivePost( requestUtils, post.id );
+		expect( archived.meta.previous_status ).toBe( 'publish' );
+		expect( archived.meta.archive_date ).toBeGreaterThan( 0 );
+		expect( archived.meta.archive_user ).toBeGreaterThan( 0 );
+
+		await unarchivePost( requestUtils, post.id );
+		const cleaned = await postState( requestUtils, post.id );
+
+		expect( cleaned.meta.previous_status ).toBe( '' );
+		expect( cleaned.meta.archive_date ).toBe( 0 );
+		expect( cleaned.meta.archive_user ).toBe( 0 );
+	} );
+
+	test( 'a second round trip restores the same state again', async ( {
+		requestUtils,
+	} ) => {
+		const post = await seedPost( requestUtils, {
+			title: uniqueTitle( 'Round trip twice' ),
+			status: 'publish',
+			comment_status: 'open',
+			ping_status: 'open',
+		} );
+		created.push( post.id );
+
+		await archivePost( requestUtils, post.id );
+		await unarchivePost( requestUtils, post.id );
+		await archivePost( requestUtils, post.id );
+		const restored = await unarchivePost( requestUtils, post.id );
+
+		expect( restored.post_status ).toBe( 'publish' );
+		expect( restored.comment_status ).toBe( 'open' );
+		expect( restored.ping_status ).toBe( 'open' );
+	} );
+} );
+
+/**
+ * `Plugin::hookables()` only registers `Archive\ArchiveMetaListener` when
+ * `aps_enable_archive_meta` resolves truthy (default `true`). With a site
+ * filtering it to `false`, archiving still transitions the status (and
+ * still forces comment/ping closed — that is `ArchiveOperation`'s own
+ * behaviour, independent of the listener), but no
+ * `_aps_archive_meta_*` postmeta is ever written. `UnarchiveOperation::
+ * resolve_restore_values()`'s legacy branch — the one pre-0.4.0 archived
+ * content always hits, since that meta never existed before 0.4.0 — is
+ * the only thing left to restore from, so unarchiving such a post must
+ * fall back to `draft` / `closed` / `closed` regardless of what the post
+ * held before it was archived.
+ */
+test.describe( 'archive / unarchive round trip: aps_enable_archive_meta disabled', () => {
+	const created: number[] = [];
+
+	test.beforeEach( async ( { requestUtils } ) => {
+		await setFixtures( requestUtils, {
+			[ FIXTURE_TOGGLES.disableArchiveMeta ]: true,
+		} );
+	} );
+
+	test.afterEach( async ( { requestUtils } ) => {
+		await deletePosts( requestUtils, created.splice( 0 ) );
+		await resetFixtures( requestUtils, [
+			FIXTURE_TOGGLES.disableArchiveMeta,
+		] );
+	} );
+
+	test( 'archiving writes no archive meta', async ( { requestUtils } ) => {
+		const post = await seedPost( requestUtils, {
+			title: uniqueTitle( 'No meta archive' ),
+			status: 'publish',
+			comment_status: 'open',
+			ping_status: 'open',
+		} );
+		created.push( post.id );
+
+		const archived = await archivePost( requestUtils, post.id );
+
+		expect( archived.post_status ).toBe( ARCHIVED_STATUS_SLUG );
+		// ArchiveOperation itself still forces discussion closed on
+		// archive — that part of the contract has no dependency on the
+		// meta listener.
+		expect( archived.comment_status ).toBe( 'closed' );
+		expect( archived.ping_status ).toBe( 'closed' );
+
+		expect( archived.meta.previous_status ).toBe( '' );
+		expect( archived.meta.archive_date ).toBe( 0 );
+		expect( archived.meta.archive_user ).toBe( 0 );
+	} );
+
+	test( 'unarchiving a no-meta archived post falls back to the legacy draft/closed/closed restore', async ( {
+		requestUtils,
+	} ) => {
+		// Published with discussion open: if a (nonexistent) meta snapshot
+		// were somehow consulted, the post would come back 'publish' /
+		// 'open' / 'open'. Only the legacy fallback produces
+		// 'draft' / 'closed' / 'closed' here, so this is what actually
+		// tells the two restore paths apart.
+		const post = await seedPost( requestUtils, {
+			title: uniqueTitle( 'No meta unarchive' ),
+			status: 'publish',
+			comment_status: 'open',
+			ping_status: 'open',
+		} );
+		created.push( post.id );
+
+		const archived = await archivePost( requestUtils, post.id );
+		expect( archived.meta.archive_date ).toBe( 0 );
+
+		const restored = await unarchivePost( requestUtils, post.id );
+
+		expect( restored.post_status ).toBe( 'draft' );
+		expect( restored.comment_status ).toBe( 'closed' );
+		expect( restored.ping_status ).toBe( 'closed' );
+	} );
+} );

--- a/tests/e2e/specs/editor/block-vs-classic.spec.ts
+++ b/tests/e2e/specs/editor/block-vs-classic.spec.ts
@@ -1,0 +1,193 @@
+/**
+ * Pins the Archive control in both editors.
+ *
+ * Block editor: `assets/js/block-editor.js` renders an Archive button into the
+ * post-status panel and guards it with a confirm dialog.
+ * Classic editor: `Admin\PostEditor::post_submitbox_archive_button()` renders an
+ * Archive link in the submit box, and `Admin\EditorContext::is_classic_editor()`
+ * (via the `aps_is_classic_editor` filter) keeps the block-editor bundle off the
+ * classic screen.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { test, expect } from '@wordpress/e2e-test-utils-playwright';
+
+/**
+ * Internal dependencies
+ */
+import { ARCHIVED_STATUS_SLUG } from '../../config/roles';
+import { noticeWith } from '../../config/admin';
+import {
+	FIXTURE_TOGGLES,
+	resetFixtures,
+	setFixtures,
+} from '../../config/fixtures';
+import {
+	deletePosts,
+	postState,
+	seedPost,
+	uniqueTitle,
+} from '../../config/seed';
+import { pluginStrings } from '../../config/strings';
+
+/**
+ * Class the block-editor bundle puts on its Archive button.
+ */
+const BLOCK_ARCHIVE_BUTTON = 'a.editor-post-archive';
+
+/**
+ * Container the classic submit box renders the Archive link into.
+ */
+const CLASSIC_ARCHIVE_LINK = '#archive-action a';
+
+/**
+ * Handle of the block-editor script, as WordPress renders its `<script>` id.
+ */
+const BLOCK_SCRIPT = 'script#aps-block-editor-js';
+
+let strings: Awaited< ReturnType< typeof pluginStrings > >;
+
+test.beforeAll( async ( { requestUtils } ) => {
+	strings = await pluginStrings( requestUtils );
+} );
+
+test.describe( 'editor: block editor archive button', () => {
+	const created: number[] = [];
+
+	test.afterEach( async ( { requestUtils } ) => {
+		await deletePosts( requestUtils, created.splice( 0 ) );
+	} );
+
+	test( 'the Archive button is rendered and archives after the confirm is accepted', async ( {
+		admin,
+		editor,
+		page,
+		requestUtils,
+	} ) => {
+		const post = await seedPost( requestUtils, {
+			title: uniqueTitle( 'Block archive' ),
+			status: 'draft',
+		} );
+		created.push( post.id );
+
+		await admin.editPost( post.id );
+		await editor.openDocumentSettingsSidebar();
+
+		const button = page.locator( BLOCK_ARCHIVE_BUTTON );
+		await expect( button ).toBeVisible();
+		await expect( button ).toHaveText( strings.archive_row_action );
+
+		page.once( 'dialog', ( dialog ) => dialog.accept() );
+		await Promise.all( [ page.waitForURL( /edit\.php/ ), button.click() ] );
+
+		await expect(
+			noticeWith( page, strings.archived_notice_one )
+		).toBeVisible();
+		expect( ( await postState( requestUtils, post.id ) ).post_status ).toBe(
+			ARCHIVED_STATUS_SLUG
+		);
+	} );
+
+	test( 'dismissing the confirm leaves the post alone', async ( {
+		admin,
+		editor,
+		page,
+		requestUtils,
+	} ) => {
+		const post = await seedPost( requestUtils, {
+			title: uniqueTitle( 'Block archive cancelled' ),
+			status: 'draft',
+		} );
+		created.push( post.id );
+
+		await admin.editPost( post.id );
+		await editor.openDocumentSettingsSidebar();
+
+		const button = page.locator( BLOCK_ARCHIVE_BUTTON );
+
+		page.once( 'dialog', ( dialog ) => dialog.dismiss() );
+		await button.click();
+
+		// The click handler calls preventDefault(), so the editor stays put.
+		await expect( button ).toBeVisible();
+		expect( page.url() ).toContain( 'post.php' );
+		expect( ( await postState( requestUtils, post.id ) ).post_status ).toBe(
+			'draft'
+		);
+	} );
+} );
+
+test.describe( 'editor: classic editor archive link', () => {
+	const created: number[] = [];
+
+	test.beforeEach( async ( { requestUtils } ) => {
+		await setFixtures( requestUtils, {
+			[ FIXTURE_TOGGLES.classicEditor ]: true,
+		} );
+	} );
+
+	test.afterEach( async ( { requestUtils } ) => {
+		await deletePosts( requestUtils, created.splice( 0 ) );
+		await resetFixtures( requestUtils, [ FIXTURE_TOGGLES.classicEditor ] );
+	} );
+
+	test( 'the submit box carries an Archive link and the block bundle is not loaded', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		const post = await seedPost( requestUtils, {
+			title: uniqueTitle( 'Classic archive' ),
+			status: 'draft',
+		} );
+		created.push( post.id );
+
+		await admin.visitAdminPage(
+			'post.php',
+			`post=${ post.id }&action=edit`
+		);
+
+		// Classic screen, not the block editor.
+		await expect( page.locator( '#submitdiv' ) ).toBeVisible();
+
+		const link = page.locator( CLASSIC_ARCHIVE_LINK );
+		await expect( link ).toBeVisible();
+		await expect( link ).toHaveText( strings.archive_row_action );
+
+		// `aps_is_classic_editor` short-circuits the enqueue, which matters:
+		// the bundle dereferences wp.element / wp.editPost and would throw
+		// on a classic screen.
+		await expect( page.locator( BLOCK_SCRIPT ) ).toHaveCount( 0 );
+	} );
+
+	test( 'the Archive link archives the post and returns to the list', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		const post = await seedPost( requestUtils, {
+			title: uniqueTitle( 'Classic archive click' ),
+			status: 'publish',
+		} );
+		created.push( post.id );
+
+		await admin.visitAdminPage(
+			'post.php',
+			`post=${ post.id }&action=edit`
+		);
+
+		await Promise.all( [
+			page.waitForURL( /edit\.php/ ),
+			page.locator( CLASSIC_ARCHIVE_LINK ).click(),
+		] );
+
+		await expect(
+			noticeWith( page, strings.archived_notice_one )
+		).toBeVisible();
+		expect( ( await postState( requestUtils, post.id ) ).post_status ).toBe(
+			ARCHIVED_STATUS_SLUG
+		);
+	} );
+} );

--- a/tests/e2e/specs/editor/read-only-guard.spec.ts
+++ b/tests/e2e/specs/editor/read-only-guard.spec.ts
@@ -1,0 +1,199 @@
+/**
+ * Pins the read-only editor guard (`Admin\PostEditorGuard`).
+ *
+ * With read-only mode on (the plugin default), opening an archived post in the
+ * editor is stopped with `wp_die()` and an exact message; the post-save
+ * round-trip is redirected to the list table instead of re-rendering the
+ * editor; and `action=unarchive` is always allowed through so the row-action
+ * flow can complete.
+ *
+ * The post-save redirect target is built by
+ * `PostListUrlBuilder::for_post_type( $post->post_type, true )` from the
+ * post's actual type — `post` gets a bare `edit.php`, everything else gets
+ * `post_type={type}` appended.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { test, expect } from '@wordpress/e2e-test-utils-playwright';
+
+/**
+ * Internal dependencies
+ */
+import { ARCHIVED_STATUS_SLUG } from '../../config/roles';
+import {
+	editUrl,
+	postListQuery,
+	rowActionLocator,
+	rowLocator,
+} from '../../config/admin';
+import {
+	archivePost,
+	deletePosts,
+	POST_TYPES,
+	postState,
+	seedPost,
+	uniqueTitle,
+} from '../../config/seed';
+import type { PostTypeUnderTest } from '../../config/seed';
+import { pluginStrings } from '../../config/strings';
+
+/**
+ * A post created during a test, tagged with the REST base `deletePosts()`
+ * needs to remove it again.
+ */
+interface CreatedPost {
+	id: number;
+	type: PostTypeUnderTest[ 'restBase' ];
+}
+
+/**
+ * Delete every tracked post, grouped by REST base.
+ *
+ * @param requestUtils Admin request utils.
+ * @param posts        Posts pushed onto the describe block's `created` array.
+ */
+async function deleteCreated(
+	requestUtils: Parameters< typeof deletePosts >[ 0 ],
+	posts: CreatedPost[]
+): Promise< void > {
+	await Promise.all(
+		POST_TYPES.map( ( { restBase } ) =>
+			deletePosts(
+				requestUtils,
+				posts
+					.filter( ( post ) => post.type === restBase )
+					.map( ( post ) => post.id ),
+				restBase
+			)
+		)
+	);
+}
+
+test.describe( 'editor: read-only guard', () => {
+	const created: CreatedPost[] = [];
+	let READ_ONLY_MESSAGE: string;
+
+	test.beforeAll( async ( { requestUtils } ) => {
+		( { read_only_message: READ_ONLY_MESSAGE } = await pluginStrings(
+			requestUtils
+		) );
+	} );
+
+	test.afterEach( async ( { requestUtils } ) => {
+		await deleteCreated( requestUtils, created.splice( 0 ) );
+	} );
+
+	test( 'opening an archived post in the editor is blocked with the exact message', async ( {
+		page,
+		requestUtils,
+	} ) => {
+		const post = await seedPost( requestUtils, {
+			title: uniqueTitle( 'Read only blocked' ),
+			status: 'publish',
+		} );
+		created.push( { id: post.id, type: 'posts' } );
+		await archivePost( requestUtils, post.id );
+
+		const response = await page.goto( editUrl( post.id ) );
+
+		expect( response?.status() ).toBe( 500 );
+		await expect( page.locator( 'body' ) ).toContainText(
+			READ_ONLY_MESSAGE
+		);
+	} );
+
+	test( 'a non-archived post still opens in the editor', async ( {
+		page,
+		requestUtils,
+	} ) => {
+		const post = await seedPost( requestUtils, {
+			title: uniqueTitle( 'Read only allowed' ),
+			status: 'draft',
+		} );
+		created.push( { id: post.id, type: 'posts' } );
+
+		const response = await page.goto( editUrl( post.id ) );
+
+		// Control: the guard is scoped to archived posts, not to the screen.
+		expect( response?.status() ).toBe( 200 );
+		await expect( page.locator( 'body' ) ).not.toContainText(
+			READ_ONLY_MESSAGE
+		);
+	} );
+
+	for ( const postType of POST_TYPES ) {
+		test( `${ postType.label }: the post-save round trip lands on the list table`, async ( {
+			page,
+			requestUtils,
+		} ) => {
+			const post = await seedPost( requestUtils, {
+				title: uniqueTitle( `Read only save ${ postType.key }` ),
+				status: 'publish',
+				type: postType.restBase,
+			} );
+			created.push( { id: post.id, type: postType.restBase } );
+			await archivePost( requestUtils, post.id );
+
+			// action=edit&message=1 is where WordPress sends the browser after a
+			// successful save; the guard turns that into a list-table redirect
+			// rather than the blocked-editor screen.
+			await page.goto( `${ editUrl( post.id ) }&message=1` );
+
+			const url = new URL( page.url() );
+			expect( url.pathname ).toContain( '/wp-admin/edit.php' );
+			expect( url.searchParams.get( 'post_type' ) ).toBe(
+				'post' === postType.key ? null : postType.queryArg
+			);
+			await expect( page.locator( 'body' ) ).not.toContainText(
+				READ_ONLY_MESSAGE
+			);
+		} );
+	}
+
+	test( 'action=unarchive is never blocked by the guard', async ( {
+		page,
+		requestUtils,
+	} ) => {
+		const post = await seedPost( requestUtils, {
+			title: uniqueTitle( 'Read only unarchive' ),
+			status: 'publish',
+		} );
+		created.push( { id: post.id, type: 'posts' } );
+		await archivePost( requestUtils, post.id );
+
+		// Without a nonce the request still gets past the guard — it fails
+		// later, on WordPress's own CSRF check, and never shows the read-only
+		// message.
+		await page.goto( editUrl( post.id, 'unarchive' ) );
+		await expect( page.locator( 'body' ) ).not.toContainText(
+			READ_ONLY_MESSAGE
+		);
+		expect( ( await postState( requestUtils, post.id ) ).post_status ).toBe(
+			ARCHIVED_STATUS_SLUG
+		);
+
+		// With the nonce the row action carries, the same action completes.
+		await page.goto(
+			`/wp-admin/edit.php?${ postListQuery( {
+				postStatus: ARCHIVED_STATUS_SLUG,
+			} ) }`
+		);
+		await rowLocator( page, post.id ).hover();
+		const href = await rowActionLocator(
+			page,
+			post.id,
+			'unarchive'
+		).getAttribute( 'href' );
+
+		await page.goto( href as string );
+
+		await expect( page.locator( 'body' ) ).not.toContainText(
+			READ_ONLY_MESSAGE
+		);
+		expect( ( await postState( requestUtils, post.id ) ).post_status ).toBe(
+			'publish'
+		);
+	} );
+} );

--- a/tests/e2e/specs/frontend/access-guard-404.spec.ts
+++ b/tests/e2e/specs/frontend/access-guard-404.spec.ts
@@ -1,0 +1,104 @@
+/**
+ * Pins the 0.3.12 front-end privacy rule enforced by `Frontend\AccessGuard`.
+ *
+ * A visitor who cannot view archived content gets a hard 404 on a singular
+ * archived post — the response status, not merely different markup — while a
+ * privileged user still gets the post.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { test, expect } from '@wordpress/e2e-test-utils-playwright';
+
+/**
+ * Internal dependencies
+ */
+import { POST_TITLE } from '../../config/admin';
+import {
+	archivePost,
+	deletePosts,
+	seedPost,
+	uniqueTitle,
+} from '../../config/seed';
+
+/**
+ * Seed a published post, archive it, and hand back its permalink.
+ *
+ * @param requestUtils Admin request utils.
+ * @param created      Id sink for teardown.
+ */
+async function seedArchived(
+	requestUtils: Parameters< typeof archivePost >[ 0 ],
+	created: number[]
+): Promise< { title: string; link: string; id: number } > {
+	const title = uniqueTitle( 'Guarded' );
+	const post = await seedPost( requestUtils, { title, status: 'publish' } );
+	created.push( post.id );
+
+	const archived = await archivePost( requestUtils, post.id );
+
+	return { title, link: archived.link, id: post.id };
+}
+
+test.describe( 'frontend: archived access guard (privileged)', () => {
+	const created: number[] = [];
+
+	test.afterEach( async ( { requestUtils } ) => {
+		await deletePosts( requestUtils, created.splice( 0 ) );
+	} );
+
+	test( 'an administrator can view a singular archived post', async ( {
+		page,
+		requestUtils,
+	} ) => {
+		const { title, link } = await seedArchived( requestUtils, created );
+
+		const response = await page.goto( link );
+
+		expect( response?.status() ).toBe( 200 );
+		await expect( page.locator( POST_TITLE ) ).toContainText( title );
+	} );
+} );
+
+test.describe( 'frontend: archived access guard (logged out)', () => {
+	test.use( { storageState: { cookies: [], origins: [] } } );
+
+	const created: number[] = [];
+
+	test.afterEach( async ( { requestUtils } ) => {
+		await deletePosts( requestUtils, created.splice( 0 ) );
+	} );
+
+	test( 'an anonymous visitor gets a 404 response for an archived post', async ( {
+		page,
+		requestUtils,
+	} ) => {
+		const { title, link } = await seedArchived( requestUtils, created );
+
+		const response = await page.goto( link );
+
+		expect( response?.status() ).toBe( 404 );
+		// The status alone could still be paired with leaked content.
+		await expect( page.getByText( title ) ).toHaveCount( 0 );
+	} );
+
+	test( 'the same URL is a 200 while the post is still published', async ( {
+		page,
+		requestUtils,
+	} ) => {
+		const title = uniqueTitle( 'Guard control' );
+		const post = await seedPost( requestUtils, {
+			title,
+			status: 'publish',
+		} );
+		created.push( post.id );
+
+		// Control: proves the 404 above comes from the archive transition and
+		// not from a bad permalink or an unpublished seed.
+		const response = await page.goto( post.link );
+
+		expect( response?.status() ).toBe( 200 );
+		await expect( page.locator( POST_TITLE ) ).toContainText( title );
+	} );
+} );

--- a/tests/e2e/specs/frontend/comments-pings-closed.spec.ts
+++ b/tests/e2e/specs/frontend/comments-pings-closed.spec.ts
@@ -1,0 +1,102 @@
+/**
+ * Pins the 0.3.12 rule that archiving closes discussion on a post.
+ *
+ * `Archive\ArchiveOperation::perform()` writes `comment_status` and
+ * `ping_status` to `closed` as part of the same `wp_update_post()` call that
+ * moves the status, and the pre-archive values are snapshotted into archive meta
+ * so unarchiving can restore them.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { test, expect } from '@wordpress/e2e-test-utils-playwright';
+
+/**
+ * Internal dependencies
+ */
+import { ARCHIVED_STATUS_SLUG } from '../../config/roles';
+import {
+	archivePost,
+	deletePosts,
+	postState,
+	seedPost,
+	uniqueTitle,
+} from '../../config/seed';
+
+/**
+ * The comment form rendered by the theme's post-comments-form block.
+ */
+const COMMENT_FORM = 'form.comment-form';
+
+test.describe( 'frontend: archiving closes comments and pings', () => {
+	const created: number[] = [];
+
+	test.afterEach( async ( { requestUtils } ) => {
+		await deletePosts( requestUtils, created.splice( 0 ) );
+	} );
+
+	test( 'an open post has both statuses closed after archiving', async ( {
+		requestUtils,
+	} ) => {
+		const post = await seedPost( requestUtils, {
+			title: uniqueTitle( 'Open discussion' ),
+			status: 'publish',
+			comment_status: 'open',
+			ping_status: 'open',
+		} );
+		created.push( post.id );
+
+		const before = await postState( requestUtils, post.id );
+		expect( before.comment_status ).toBe( 'open' );
+		expect( before.ping_status ).toBe( 'open' );
+
+		const after = await archivePost( requestUtils, post.id );
+
+		expect( after.post_status ).toBe( ARCHIVED_STATUS_SLUG );
+		expect( after.comment_status ).toBe( 'closed' );
+		expect( after.ping_status ).toBe( 'closed' );
+	} );
+
+	test( 'the pre-archive discussion state is snapshotted into archive meta', async ( {
+		requestUtils,
+	} ) => {
+		const post = await seedPost( requestUtils, {
+			title: uniqueTitle( 'Snapshot discussion' ),
+			status: 'publish',
+			comment_status: 'open',
+			ping_status: 'open',
+		} );
+		created.push( post.id );
+
+		const after = await archivePost( requestUtils, post.id );
+
+		// The listener records the pre-archive object, not a re-read (contract
+		// C3) — so the snapshot must be `open`, not the `closed` the same
+		// update just wrote.
+		expect( after.meta.comment_status ).toBe( 'open' );
+		expect( after.meta.ping_status ).toBe( 'open' );
+		expect( after.meta.previous_status ).toBe( 'publish' );
+	} );
+
+	test( 'the front-end comment form is present before archiving and gone after', async ( {
+		page,
+		requestUtils,
+	} ) => {
+		const post = await seedPost( requestUtils, {
+			title: uniqueTitle( 'Commentable' ),
+			status: 'publish',
+			comment_status: 'open',
+			ping_status: 'open',
+		} );
+		created.push( post.id );
+
+		await page.goto( post.link );
+		await expect( page.locator( COMMENT_FORM ) ).toBeVisible();
+
+		const archived = await archivePost( requestUtils, post.id );
+
+		await page.goto( archived.link );
+		await expect( page.locator( COMMENT_FORM ) ).toHaveCount( 0 );
+	} );
+} );

--- a/tests/e2e/specs/frontend/feed-exclusion.spec.ts
+++ b/tests/e2e/specs/frontend/feed-exclusion.spec.ts
@@ -1,0 +1,58 @@
+/**
+ * Pins that an anonymous visitor's `/feed/` omits archived posts. Exercises
+ * the archived status's `public => false` registration in
+ * `PostStatus::status_args()`.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { test, expect } from '@wordpress/e2e-test-utils-playwright';
+
+/**
+ * Internal dependencies
+ */
+import {
+	archivePost,
+	deletePosts,
+	seedPost,
+	uniqueTitle,
+} from '../../config/seed';
+
+test.describe( 'frontend: archived posts are excluded from the site feed', () => {
+	test.use( { storageState: { cookies: [], origins: [] } } );
+
+	const created: number[] = [];
+
+	test.afterEach( async ( { requestUtils } ) => {
+		await deletePosts( requestUtils, created.splice( 0 ) );
+	} );
+
+	test( 'the feed lists the published post but not the archived one', async ( {
+		page,
+		requestUtils,
+	} ) => {
+		const visibleTitle = uniqueTitle( 'Feed listed' );
+		const hiddenTitle = uniqueTitle( 'Feed archived' );
+
+		const visible = await seedPost( requestUtils, {
+			title: visibleTitle,
+			status: 'publish',
+		} );
+		const hidden = await seedPost( requestUtils, {
+			title: hiddenTitle,
+			status: 'publish',
+		} );
+		created.push( visible.id, hidden.id );
+
+		await archivePost( requestUtils, hidden.id );
+
+		const response = await page.goto( '/feed/' );
+		const body = ( await response?.text() ) ?? '';
+
+		// The control post proves the feed body was actually fetched, so the
+		// absence assertion below cannot pass vacuously.
+		expect( body ).toContain( visibleTitle );
+		expect( body ).not.toContain( hiddenTitle );
+	} );
+} );

--- a/tests/e2e/specs/frontend/public-archive.spec.ts
+++ b/tests/e2e/specs/frontend/public-archive.spec.ts
@@ -1,0 +1,87 @@
+/**
+ * Pins the published recipe for making archived content publicly readable.
+ *
+ * The plugin's readme documents three filters for this:
+ *
+ *   add_filter( 'aps_status_arg_public', '__return_true' );
+ *   add_filter( 'aps_status_arg_private', '__return_false' );
+ *   add_filter( 'aps_status_arg_exclude_from_search', '__return_false' );
+ *
+ * That worked in 0.3.x, where front-end visibility came entirely from the
+ * registered status arguments. 0.4.0 added `Frontend\AccessGuard`, which
+ * independently re-checks the view capability on `template_redirect` — and
+ * because a logged-out visitor holds no capabilities at all, it silently
+ * overrode the recipe with a 404 that no filter could lift. The guard now
+ * stands down when the status is registered public.
+ *
+ * Both directions are asserted: with the recipe off, anonymous visitors are
+ * still refused (the guard has not been defanged); with it on, the documented
+ * behaviour works.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { test, expect } from '@wordpress/e2e-test-utils-playwright';
+
+/**
+ * Internal dependencies
+ */
+import {
+	FIXTURE_TOGGLES,
+	resetFixtures,
+	setFixtures,
+} from '../../config/fixtures';
+import {
+	archivePost,
+	deletePosts,
+	seedPost,
+	uniqueTitle,
+} from '../../config/seed';
+
+test.describe( 'frontend: publicly readable archived content', () => {
+	// Anonymous: no cookies, no stored authentication.
+	test.use( { storageState: { cookies: [], origins: [] } } );
+
+	const created: number[] = [];
+
+	test.afterEach( async ( { requestUtils } ) => {
+		await resetFixtures( requestUtils );
+		await deletePosts( requestUtils, created.splice( 0 ) );
+	} );
+
+	test( 'anonymous visitors are refused by default', async ( {
+		page,
+		requestUtils,
+	} ) => {
+		const title = uniqueTitle( 'Public archive default' );
+		const post = await seedPost( requestUtils, { title, status: 'publish' } );
+		created.push( post.id );
+
+		const archived = await archivePost( requestUtils, post.id );
+		const response = await page.goto( archived.link );
+
+		expect( response?.status() ).toBe( 404 );
+		await expect( page.getByText( title ) ).toHaveCount( 0 );
+	} );
+
+	test( 'the documented status-argument recipe makes them readable', async ( {
+		page,
+		requestUtils,
+	} ) => {
+		const title = uniqueTitle( 'Public archive recipe' );
+		const post = await seedPost( requestUtils, { title, status: 'publish' } );
+		created.push( post.id );
+
+		const archived = await archivePost( requestUtils, post.id );
+
+		await setFixtures( requestUtils, {
+			[ FIXTURE_TOGGLES.publicArchive ]: true,
+		} );
+
+		const response = await page.goto( archived.link );
+
+		expect( response?.status() ).toBe( 200 );
+		await expect( page.getByText( title ).first() ).toBeVisible();
+	} );
+} );

--- a/tests/e2e/specs/frontend/search-exclusion.spec.ts
+++ b/tests/e2e/specs/frontend/search-exclusion.spec.ts
@@ -1,0 +1,64 @@
+/**
+ * Pins that an anonymous visitor's front-end search results omit archived
+ * posts. Exercises the archived status's `public => false` registration in
+ * `PostStatus::status_args()`.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { test, expect } from '@wordpress/e2e-test-utils-playwright';
+
+/**
+ * Internal dependencies
+ */
+import {
+	archivePost,
+	deletePosts,
+	seedPost,
+	uniqueTitle,
+} from '../../config/seed';
+
+test.describe( 'frontend: archived posts are excluded from search results', () => {
+	test.use( { storageState: { cookies: [], origins: [] } } );
+
+	const created: number[] = [];
+
+	test.afterEach( async ( { requestUtils } ) => {
+		await deletePosts( requestUtils, created.splice( 0 ) );
+	} );
+
+	test( 'an anonymous visitor finds the published post but not the archived one', async ( {
+		page,
+		requestUtils,
+	} ) => {
+		const term = uniqueTitle( 'Searchable' );
+		const visibleTitle = `${ term } published`;
+		const hiddenTitle = `${ term } archived`;
+
+		const visible = await seedPost( requestUtils, {
+			title: visibleTitle,
+			status: 'publish',
+		} );
+		const hidden = await seedPost( requestUtils, {
+			title: hiddenTitle,
+			status: 'publish',
+		} );
+		created.push( visible.id, hidden.id );
+
+		await archivePost( requestUtils, hidden.id );
+
+		await page.goto( `/?s=${ encodeURIComponent( term ) }` );
+
+		// The control post proves the search actually ran against this term,
+		// so the absence assertion below cannot pass vacuously. Scoped to the
+		// level-2 result heading: the theme's "More posts" widget renders
+		// unrelated recent posts as h3s on the same page.
+		await expect(
+			page
+				.getByRole( 'heading', { level: 2, name: visibleTitle } )
+				.getByRole( 'link' )
+		).toBeVisible();
+		await expect( page.getByText( hiddenTitle ) ).toHaveCount( 0 );
+	} );
+} );

--- a/tests/e2e/specs/frontend/title-and-listing.spec.ts
+++ b/tests/e2e/specs/frontend/title-and-listing.spec.ts
@@ -1,0 +1,147 @@
+/**
+ * Pins the 0.3.12 front-end title contract and the listing exclusion.
+ *
+ * - `Frontend\ArchiveTitle` prefixes archived titles with the archived label and
+ *   a separator, and both are filterable (`aps_title_label`,
+ *   `aps_title_label_before`, `aps_title_separator`).
+ * - Archived posts do not leak into the blog listing for visitors who cannot
+ *   view archived content.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { test, expect } from '@wordpress/e2e-test-utils-playwright';
+
+/**
+ * Internal dependencies
+ */
+import { POST_TITLE } from '../../config/admin';
+import {
+	FIXTURE_TITLE_LABEL,
+	FIXTURE_TITLE_SEPARATOR,
+	FIXTURE_TOGGLES,
+	resetFixtures,
+	setFixtures,
+} from '../../config/fixtures';
+import {
+	ARCHIVED_STATUS_LABEL,
+	ARCHIVED_STATUS_SLUG,
+} from '../../config/roles';
+import {
+	archivePost,
+	deletePosts,
+	seedPost,
+	uniqueTitle,
+} from '../../config/seed';
+
+test.describe( 'frontend: archived title label', () => {
+	const created: number[] = [];
+
+	test.afterEach( async ( { requestUtils } ) => {
+		await deletePosts( requestUtils, created.splice( 0 ) );
+		await resetFixtures( requestUtils, [ FIXTURE_TOGGLES.titleFilters ] );
+	} );
+
+	test( 'a singular archived post is titled "Archived: <title>"', async ( {
+		page,
+		requestUtils,
+	} ) => {
+		const title = uniqueTitle( 'Title prefix' );
+		const post = await seedPost( requestUtils, {
+			title,
+			status: 'publish',
+		} );
+		created.push( post.id );
+
+		const archived = await archivePost( requestUtils, post.id );
+		expect( archived.post_status ).toBe( ARCHIVED_STATUS_SLUG );
+
+		const response = await page.goto( archived.link );
+		expect( response?.status() ).toBe( 200 );
+
+		await expect( page.locator( POST_TITLE ) ).toHaveText(
+			`${ ARCHIVED_STATUS_LABEL }: ${ title }`
+		);
+	} );
+
+	test( 'a published post is not prefixed', async ( {
+		page,
+		requestUtils,
+	} ) => {
+		const title = uniqueTitle( 'Unprefixed' );
+		const post = await seedPost( requestUtils, {
+			title,
+			status: 'publish',
+		} );
+		created.push( post.id );
+
+		await page.goto( post.link );
+
+		await expect( page.locator( POST_TITLE ) ).toHaveText( title );
+	} );
+
+	test( 'the label, position and separator filters compose the title', async ( {
+		page,
+		requestUtils,
+	} ) => {
+		await setFixtures( requestUtils, {
+			[ FIXTURE_TOGGLES.titleFilters ]: true,
+		} );
+
+		const title = uniqueTitle( 'Filtered title' );
+		const post = await seedPost( requestUtils, {
+			title,
+			status: 'publish',
+		} );
+		created.push( post.id );
+
+		const archived = await archivePost( requestUtils, post.id );
+		await page.goto( archived.link );
+
+		// `aps_title_label_before` is false, so ArchiveTitle appends the
+		// separator and label in that order.
+		await expect( page.locator( POST_TITLE ) ).toHaveText(
+			`${ title }${ FIXTURE_TITLE_SEPARATOR }${ FIXTURE_TITLE_LABEL }`
+		);
+	} );
+} );
+
+test.describe( 'frontend: archived posts are excluded from the blog listing', () => {
+	test.use( { storageState: { cookies: [], origins: [] } } );
+
+	const created: number[] = [];
+
+	test.afterEach( async ( { requestUtils } ) => {
+		await deletePosts( requestUtils, created.splice( 0 ) );
+	} );
+
+	test( 'an anonymous visitor sees the published post but not the archived one', async ( {
+		page,
+		requestUtils,
+	} ) => {
+		const visibleTitle = uniqueTitle( 'Listed post' );
+		const hiddenTitle = uniqueTitle( 'Archived post' );
+
+		const visible = await seedPost( requestUtils, {
+			title: visibleTitle,
+			status: 'publish',
+		} );
+		const hidden = await seedPost( requestUtils, {
+			title: hiddenTitle,
+			status: 'publish',
+		} );
+		created.push( visible.id, hidden.id );
+
+		await archivePost( requestUtils, hidden.id );
+
+		await page.goto( '/' );
+
+		// The control post proves the listing rendered at all, so the absence
+		// assertion below cannot pass vacuously.
+		await expect(
+			page.getByRole( 'link', { name: visibleTitle } )
+		).toBeVisible();
+		await expect( page.getByText( hiddenTitle ) ).toHaveCount( 0 );
+	} );
+} );

--- a/tests/e2e/specs/plugins/deactivation-warning.spec.ts
+++ b/tests/e2e/specs/plugins/deactivation-warning.spec.ts
@@ -1,0 +1,203 @@
+/**
+ * Pins the deactivation warning on the Plugins screen.
+ *
+ * `assets/js/plugin-screen.js` (enqueued by `Admin\PluginScreen`) confirms
+ * before deactivating this plugin whenever archived content exists —
+ * deactivating unregisters the archived post status, which would leave that
+ * content in limbo. With no archived content, the confirm is skipped
+ * entirely and the Deactivate link behaves like any other plugin's. The same
+ * confirm also fires on Bulk Actions -> Deactivate when this plugin's row is
+ * among the checked items.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { test, expect } from '@wordpress/e2e-test-utils-playwright';
+import type { RequestUtils } from '@wordpress/e2e-test-utils-playwright';
+
+/**
+ * Internal dependencies
+ */
+import { PLUGIN_SLUG } from '../../config/roles';
+import { archivePost, deletePosts, seedPost, uniqueTitle } from '../../config/seed';
+import { wpCli } from '../../config/wp-cli';
+
+/**
+ * Handle of the deactivation-warning script, as WordPress renders its
+ * `<script>` id.
+ */
+const PLUGIN_SCREEN_SCRIPT = 'script#aps-plugin-screen-js';
+
+/**
+ * The plugin row on `plugins.php`, keyed by the same `data-slug` the
+ * production JS itself queries.
+ */
+const PLUGIN_ROW = `tr[data-slug="${ PLUGIN_SLUG }"]`;
+
+/**
+ * Whether the plugin under test is currently active, per the core plugins
+ * REST endpoint.
+ *
+ * @param requestUtils Admin request utils.
+ */
+async function isPluginActive( requestUtils: RequestUtils ): Promise< boolean > {
+	const plugins = await requestUtils.rest< Array< { plugin: string; status: string } > >( {
+		path: '/wp/v2/plugins',
+	} );
+
+	const plugin = plugins.find( ( candidate ) =>
+		candidate.plugin.startsWith( `${ PLUGIN_SLUG }/` )
+	);
+
+	return 'active' === plugin?.status;
+}
+
+test.describe( 'plugins screen: deactivation warning', () => {
+	const created: number[] = [];
+
+	test.afterEach( async ( { requestUtils } ) => {
+		await deletePosts( requestUtils, created.splice( 0 ) );
+		// Safety net regardless of which path a test took above — every
+		// other spec depends on the plugin being active.
+		await requestUtils.activatePlugin( PLUGIN_SLUG );
+	} );
+
+	test( 'the script is enqueued on the Plugins screen', async ( {
+		admin,
+		page,
+	} ) => {
+		await admin.visitAdminPage( 'plugins.php' );
+
+		await expect( page.locator( PLUGIN_SCREEN_SCRIPT ) ).toHaveCount( 1 );
+	} );
+
+	test( 'accepting the warning deactivates the plugin', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		const post = await seedPost( requestUtils, {
+			title: uniqueTitle( 'Deactivation warning accept' ),
+			status: 'publish',
+		} );
+		created.push( post.id );
+		await archivePost( requestUtils, post.id );
+
+		await admin.visitAdminPage( 'plugins.php' );
+
+		page.once( 'dialog', ( dialog ) => dialog.accept() );
+		await Promise.all( [
+			page.waitForURL( /deactivate=true/ ),
+			page.locator( PLUGIN_ROW ).locator( '.deactivate a' ).click(),
+		] );
+
+		expect( await isPluginActive( requestUtils ) ).toBe( false );
+	} );
+
+	test( 'dismissing the warning leaves the plugin active', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		const post = await seedPost( requestUtils, {
+			title: uniqueTitle( 'Deactivation warning dismiss' ),
+			status: 'publish',
+		} );
+		created.push( post.id );
+		await archivePost( requestUtils, post.id );
+
+		await admin.visitAdminPage( 'plugins.php' );
+
+		page.once( 'dialog', ( dialog ) => dialog.dismiss() );
+		// The click handler calls preventDefault() on dismiss, so no
+		// navigation follows — nothing here to await beyond the click.
+		await page.locator( PLUGIN_ROW ).locator( '.deactivate a' ).click();
+
+		expect( page.url() ).toContain( 'plugins.php' );
+		expect( await isPluginActive( requestUtils ) ).toBe( true );
+	} );
+
+	test( 'accepting the warning via Bulk Actions -> Deactivate deactivates the plugin', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		const post = await seedPost( requestUtils, {
+			title: uniqueTitle( 'Deactivation warning bulk accept' ),
+			status: 'publish',
+		} );
+		created.push( post.id );
+		await archivePost( requestUtils, post.id );
+
+		await admin.visitAdminPage( 'plugins.php' );
+
+		await page.locator( PLUGIN_ROW ).locator( 'input[type="checkbox"]' ).check();
+		await page.locator( '#bulk-action-selector-top' ).selectOption( 'deactivate-selected' );
+
+		page.once( 'dialog', ( dialog ) => dialog.accept() );
+		await Promise.all( [
+			page.waitForURL( /deactivate-multi=true/ ),
+			page.locator( '#doaction' ).click(),
+		] );
+
+		expect( await isPluginActive( requestUtils ) ).toBe( false );
+	} );
+
+	test( 'dismissing the warning via Bulk Actions -> Deactivate leaves the plugin active', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		const post = await seedPost( requestUtils, {
+			title: uniqueTitle( 'Deactivation warning bulk dismiss' ),
+			status: 'publish',
+		} );
+		created.push( post.id );
+		await archivePost( requestUtils, post.id );
+
+		await admin.visitAdminPage( 'plugins.php' );
+
+		await page.locator( PLUGIN_ROW ).locator( 'input[type="checkbox"]' ).check();
+		await page.locator( '#bulk-action-selector-top' ).selectOption( 'deactivate-selected' );
+
+		page.once( 'dialog', ( dialog ) => dialog.dismiss() );
+		// As with the single-link dismiss test above, preventDefault() on
+		// dismiss blocks the form submit outright — nothing here to await
+		// beyond the click.
+		await page.locator( '#doaction' ).click();
+
+		expect( page.url() ).toContain( 'plugins.php' );
+		expect( await isPluginActive( requestUtils ) ).toBe( true );
+	} );
+
+	test( 'with no archived content, the Deactivate link needs no confirmation', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		// This test's premise is a truly clean slate: purge any archived
+		// posts left behind by an abnormally terminated earlier run (a
+		// cleanup trap cannot fire on SIGKILL).
+		await wpCli( [
+			'eval',
+			'foreach ( get_posts( array( "post_status" => "archive", "post_type" => "any", "numberposts" => -1, "fields" => "ids" ) ) as $stray ) { wp_delete_post( $stray, true ); }',
+		] );
+
+		let dialogSeen = false;
+		page.on( 'dialog', ( dialog ) => {
+			dialogSeen = true;
+			dialog.dismiss();
+		} );
+
+		await admin.visitAdminPage( 'plugins.php' );
+
+		await Promise.all( [
+			page.waitForURL( /deactivate=true/ ),
+			page.locator( PLUGIN_ROW ).locator( '.deactivate a' ).click(),
+		] );
+
+		expect( dialogSeen ).toBe( false );
+		expect( await isPluginActive( requestUtils ) ).toBe( false );
+	} );
+} );

--- a/tests/e2e/specs/plugins/upgrade-check.spec.ts
+++ b/tests/e2e/specs/plugins/upgrade-check.spec.ts
@@ -1,0 +1,132 @@
+/**
+ * Pins the pre-0.4.0 upgrade marker written by `Plugin::upgrade_check()`.
+ *
+ * On the first admin page load where the `archived_post_status_version`
+ * option does not exist, the plugin distinguishes a genuinely fresh install
+ * from an upgrade out of a release that predates the option entirely (every
+ * pre-0.4.0 release never wrote it). `Plugin::has_pre_040_content()` probes
+ * for the literal `archive` post_status — the only signal that survives from
+ * a pre-0.4.0 site, since that status was hardcoded into every write
+ * regardless of the `aps_post_status_slug` filter. When that probe finds
+ * content, the plugin records `archived_post_status_previous_version =
+ * 'pre-0.4.0'` alongside the current version; with no such content, only the
+ * version option is written.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { test, expect } from '@wordpress/e2e-test-utils-playwright';
+
+/**
+ * Internal dependencies
+ */
+import { wpCli, wpCliOk } from '../../config/wp-cli';
+
+/**
+ * Option names `Plugin::upgrade_check()` reads and writes.
+ *
+ * @see src/Plugin.php
+ */
+const VERSION_OPTION = 'archived_post_status_version';
+const PREVIOUS_VERSION_OPTION = 'archived_post_status_previous_version';
+
+/**
+ * Shape returned by {@link readUpgradeMarkerState}.
+ */
+interface UpgradeMarkerState {
+	version: string;
+	stored_version: string | false;
+	previous_version: string | false;
+}
+
+/**
+ * Delete both upgrade-marker options via a raw `delete_option()` call rather
+ * than `wp option delete`, which exits non-zero when the option is already
+ * absent — this needs to be a clean, always-succeeds reset.
+ */
+async function resetUpgradeMarkers(): Promise< void > {
+	await wpCliOk( [
+		'eval',
+		`delete_option( '${ VERSION_OPTION }' ); delete_option( '${ PREVIOUS_VERSION_OPTION }' );`,
+	] );
+}
+
+/**
+ * Purge every post carrying the plugin's archived status, including ones
+ * created directly at the database layer (raw `post_status=archive`) that
+ * the REST-based cleanup helpers in `config/seed.ts` cannot see, so
+ * `has_pre_040_content()`'s literal-status probe starts from a known-empty
+ * slate.
+ */
+async function purgeArchivedPosts(): Promise< void > {
+	await wpCli( [
+		'eval',
+		'foreach ( get_posts( array( "post_status" => "archive", "post_type" => "any", "numberposts" => -1, "fields" => "ids" ) ) as $stray ) { wp_delete_post( $stray, true ); }',
+	] );
+}
+
+/**
+ * Read the plugin's version constant plus both upgrade-marker options in one
+ * round trip.
+ */
+async function readUpgradeMarkerState(): Promise< UpgradeMarkerState > {
+	const output = await wpCliOk( [
+		'eval',
+		`echo json_encode( array(
+			'version'          => ARCHIVED_POST_STATUS_VERSION,
+			'stored_version'   => get_option( '${ VERSION_OPTION }', false ),
+			'previous_version' => get_option( '${ PREVIOUS_VERSION_OPTION }', false )
+		) );`,
+	] );
+
+	return JSON.parse( output );
+}
+
+test.describe( 'plugin: pre-0.4.0 upgrade marker', () => {
+	test.beforeEach( async () => {
+		await resetUpgradeMarkers();
+		await purgeArchivedPosts();
+	} );
+
+	test.afterEach( async () => {
+		await purgeArchivedPosts();
+	} );
+
+	test( 'raw "archive" content predating the version option records the pre-0.4.0 marker on the next admin load', async ( {
+		admin,
+	} ) => {
+		// Bypass the plugin's own API entirely: a bare `wp post create`
+		// writes the literal status straight to wp_posts with no
+		// aps_archive_post() call and therefore no archive meta — exactly
+		// the shape pre-0.4.0 archived content takes, since archive meta
+		// did not exist before 0.4.0 either.
+		const legacyPostId = Number(
+			await wpCliOk( [
+				'post',
+				'create',
+				'--post_status=archive',
+				'--post_title=Pre-0.4.0 legacy content',
+				'--porcelain',
+			] )
+		);
+		expect( legacyPostId ).toBeGreaterThan( 0 );
+
+		// Any admin page load reaches Plugin::run() -> upgrade_check().
+		await admin.visitAdminPage( 'edit.php' );
+
+		const state = await readUpgradeMarkerState();
+		expect( state.stored_version ).toBe( state.version );
+		expect( state.previous_version ).toBe( 'pre-0.4.0' );
+	} );
+
+	test( 'with no archived content, only the version option is written', async ( {
+		admin,
+	} ) => {
+		await admin.visitAdminPage( 'edit.php' );
+
+		const state = await readUpgradeMarkerState();
+		expect( state.stored_version ).toBe( state.version );
+		expect( state.previous_version ).toBe( false );
+	} );
+} );

--- a/tests/e2e/specs/post-list/archived-column.spec.ts
+++ b/tests/e2e/specs/post-list/archived-column.spec.ts
@@ -1,0 +1,428 @@
+/**
+ * Pins the 0.4.0 Archived column added by `Admin\ArchiveColumn`.
+ *
+ * The column only appears on the archived filter, attributes each row to the
+ * user who archived it (falling back to "system" when there was no user, e.g.
+ * anonymous WP-CLI), renders the archive timestamp, and is sortable by that
+ * timestamp.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { test, expect } from '@wordpress/e2e-test-utils-playwright';
+
+/**
+ * Internal dependencies
+ */
+import { ARCHIVED_STATUS_SLUG } from '../../config/roles';
+import { postListQuery, rowLocator } from '../../config/admin';
+import {
+	archivePost,
+	deletePosts,
+	POST_TYPES,
+	postState,
+	seedPost,
+	setArchiveMeta,
+	uniqueTitle,
+} from '../../config/seed';
+import type { PostTypeUnderTest } from '../../config/seed';
+import { pluginStrings } from '../../config/strings';
+import { wpCli } from '../../config/wp-cli';
+
+/**
+ * A post created during a test, tagged with the REST base `deletePosts()`
+ * needs to remove it again. Several tests below loop {@link POST_TYPES},
+ * seeding more than one type into the same `created` array, so a single
+ * hardcoded base would silently fail to delete anything but `post`.
+ */
+interface CreatedPost {
+	id: number;
+	type: PostTypeUnderTest[ 'restBase' ];
+}
+
+/**
+ * Delete every tracked post, grouped by REST base.
+ *
+ * @param requestUtils Admin request utils.
+ * @param posts        Posts pushed onto the describe block's `created` array.
+ */
+async function deleteCreated(
+	requestUtils: Parameters< typeof deletePosts >[ 0 ],
+	posts: CreatedPost[]
+): Promise< void > {
+	await Promise.all(
+		POST_TYPES.map( ( { restBase } ) =>
+			deletePosts(
+				requestUtils,
+				posts
+					.filter( ( post ) => post.type === restBase )
+					.map( ( post ) => post.id ),
+				restBase
+			)
+		)
+	);
+}
+
+/**
+ * Delete every tracked test user, ignoring ids already gone.
+ *
+ * Used from `afterEach` as a safety net for the deleted-user attribution
+ * test below: that test deletes its own throwaway user as part of the
+ * scenario it is proving, so this is a no-op on the happy path and only
+ * matters if the test fails before reaching that step.
+ *
+ * @param requestUtils Admin request utils.
+ * @param userIds      User ids pushed onto the describe block's `createdUsers` array.
+ */
+async function deleteCreatedUsers(
+	requestUtils: Parameters< typeof deletePosts >[ 0 ],
+	userIds: number[]
+): Promise< void > {
+	await Promise.all(
+		userIds.map( async ( id ) => {
+			try {
+				await requestUtils.rest( {
+					method: 'DELETE',
+					path: `/wp/v2/users/${ id }`,
+					params: { force: true, reassign: 1 },
+				} );
+			} catch {
+				// Already deleted — teardown stays best-effort.
+			}
+		} )
+	);
+}
+
+let usernameCounter = 0;
+
+/**
+ * Build a WP-CLI-safe username that is unique across specs, runs and workers.
+ *
+ * Mirrors {@link uniqueTitle}'s uniqueness strategy, but restricted to the
+ * character set `wp user create` accepts without quoting trouble.
+ *
+ * @param prefix Human-readable prefix.
+ */
+function uniqueUsername( prefix: string ): string {
+	usernameCounter += 1;
+
+	return `${ prefix }_${ Date.now().toString( 36 ) }_${ usernameCounter }`;
+}
+
+/**
+ * Column key registered by `ArchiveColumn::COLUMN_KEY`.
+ */
+const COLUMN_KEY = 'aps_archived';
+
+/**
+ * A timestamp with an unambiguous rendering: 2001-09-09 01:46:40 UTC.
+ *
+ * Pinning the stored `archive_date` keeps both the rendered-date assertion and
+ * the sort assertion deterministic — `ArchiveMeta::from_post()` stamps `time()`,
+ * so two posts archived in the same second would otherwise tie.
+ */
+const FIXED_TIMESTAMP = 1_000_000_000;
+
+/**
+ * `wp_date( get_option( 'date_format' ) . ' \a\t ' . get_option( 'time_format' ), FIXED_TIMESTAMP )`
+ * with the stock WordPress settings asserted below.
+ */
+const FIXED_TIMESTAMP_DISPLAY = 'September 9, 2001 at 1:46 am';
+
+const ARCHIVED_VIEW = postListQuery( { postStatus: ARCHIVED_STATUS_SLUG } );
+
+test.describe( 'post list: archived column', () => {
+	const created: CreatedPost[] = [];
+	const createdUsers: number[] = [];
+	let strings: Awaited< ReturnType< typeof pluginStrings > >;
+
+	test.beforeAll( async ( { requestUtils } ) => {
+		strings = await pluginStrings( requestUtils );
+	} );
+
+	test.afterEach( async ( { requestUtils } ) => {
+		await deleteCreated( requestUtils, created.splice( 0 ) );
+		await deleteCreatedUsers( requestUtils, createdUsers.splice( 0 ) );
+	} );
+
+	// The three tests below loop every {@link POST_TYPES} entry:
+	// `ArchiveColumn::hooks()` (src/Admin/ArchiveColumn.php) registers
+	// `manage_{type}_posts_columns`, `manage_{type}_posts_custom_column` and
+	// `manage_edit-{type}_sortable_columns` per post type — three independent
+	// registration points a partial fix could wire for `post` while missing
+	// `page`/`book` (add the column but forget it sortable, for instance).
+	// This test covers the first: a loop that skipped a type would never add
+	// the `th#aps_archived` header there at all.
+	for ( const postType of POST_TYPES ) {
+		test( `${ postType.label }: the column is registered on the archived view and absent from All`, async ( {
+			admin,
+			page,
+			requestUtils,
+		} ) => {
+			const post = await seedPost( requestUtils, {
+				title: uniqueTitle( `Column visibility ${ postType.key }` ),
+				status: 'publish',
+				type: postType.restBase,
+			} );
+			created.push( { id: post.id, type: postType.restBase } );
+
+			await admin.visitAdminPage(
+				'edit.php',
+				postListQuery( { postType: postType.queryArg } )
+			);
+			await expect(
+				page.locator( `th#${ COLUMN_KEY }` )
+			).toHaveCount( 0 );
+
+			await archivePost( requestUtils, post.id );
+
+			await admin.visitAdminPage(
+				'edit.php',
+				postListQuery( {
+					postType: postType.queryArg,
+					postStatus: ARCHIVED_STATUS_SLUG,
+				} )
+			);
+			await expect( page.locator( `th#${ COLUMN_KEY }` ) ).toContainText(
+				strings.archived_column_label
+			);
+		} );
+	}
+
+	// Covers the second registration point: `manage_{type}_posts_custom_column`
+	// is what actually renders the cell content; without it the `<td>` may
+	// exist (from the columns filter above) but stay empty for the skipped
+	// type.
+	for ( const postType of POST_TYPES ) {
+		test( `${ postType.label }: the cell attributes the archive to the user and shows the date`, async ( {
+			admin,
+			page,
+			requestUtils,
+		} ) => {
+			// The expected date string below assumes stock formatting; assert it so
+			// a settings change fails here rather than as a puzzling text mismatch.
+			const settings = await requestUtils.rest< {
+				date_format: string;
+				time_format: string;
+				timezone: string;
+			} >( { path: '/wp/v2/settings' } );
+			expect( settings.date_format ).toBe( 'F j, Y' );
+			expect( settings.time_format ).toBe( 'g:i a' );
+			expect( settings.timezone ).toBe( '' );
+
+			const post = await seedPost( requestUtils, {
+				title: uniqueTitle( `Column attribution ${ postType.key }` ),
+				status: 'publish',
+				type: postType.restBase,
+			} );
+			created.push( { id: post.id, type: postType.restBase } );
+
+			const archived = await archivePost( requestUtils, post.id );
+			expect( archived.meta.archive_user ).toBeGreaterThan( 0 );
+
+			await setArchiveMeta( requestUtils, post.id, {
+				archive_date: FIXED_TIMESTAMP,
+			} );
+
+			await admin.visitAdminPage(
+				'edit.php',
+				postListQuery( {
+					postType: postType.queryArg,
+					postStatus: ARCHIVED_STATUS_SLUG,
+				} )
+			);
+
+			const cell = rowLocator( page, post.id ).locator(
+				`td.column-${ COLUMN_KEY }`
+			);
+
+			await expect( cell ).toContainText(
+				strings.attribution_template.replace( '%1$s', 'admin' )
+			);
+			await expect( cell.locator( '.aps-archive-datetime' ) ).toHaveText(
+				FIXED_TIMESTAMP_DISPLAY
+			);
+		} );
+	}
+
+	// Deliberately NOT parameterized over POST_TYPES: this test's signal is
+	// the archive_user === 0 fallback in resolve_archive_agent_name() — logic
+	// with no post-type branch — not the column's per-type registration,
+	// which the two tests above already exercise for every {@link
+	// POST_TYPES} entry (including the cell-rendering hook this test also
+	// happens to exercise).
+	test( 'a post archived by anonymous WP-CLI is attributed to "system"', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		const post = await seedPost( requestUtils, {
+			title: uniqueTitle( 'Column system' ),
+			status: 'publish',
+		} );
+		created.push( { id: post.id, type: 'posts' } );
+
+		// No --user: WP-CLI's elevated context has no current user, so
+		// ArchiveMeta records user 0 and the column must fall back.
+		const cli = await wpCli( [ 'post', 'archive', String( post.id ) ] );
+		expect( cli.exitCode ).toBe( 0 );
+
+		const state = await postState( requestUtils, post.id );
+		expect( state.post_status ).toBe( ARCHIVED_STATUS_SLUG );
+		expect( state.meta.archive_user ).toBe( 0 );
+		expect( state.meta.archive_date ).toBeGreaterThan( 0 );
+
+		await admin.visitAdminPage( 'edit.php', ARCHIVED_VIEW );
+
+		const cell = rowLocator( page, post.id ).locator(
+			`td.column-${ COLUMN_KEY }`
+		);
+
+		await expect( cell ).toContainText(
+			strings.attribution_template.replace(
+				'%1$s',
+				strings.system_attribution
+			)
+		);
+		await expect( cell.locator( '.aps-archive-datetime' ) ).not.toBeEmpty();
+	} );
+
+	// Deliberately NOT parameterized over POST_TYPES, for the same reason as
+	// the "system" test above: this pins resolve_archive_agent_name()'s
+	// OTHER fallback branch — archive_user > 0 but get_userdata() fails
+	// because that account was deleted after archiving — which has no
+	// post-type branch either.
+	test( 'a post archived by a user whose account was later deleted is attributed to "Unknown"', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		const post = await seedPost( requestUtils, {
+			title: uniqueTitle( 'Column deleted user' ),
+			status: 'publish',
+		} );
+		created.push( { id: post.id, type: 'posts' } );
+
+		// A throwaway administrator: edit_others_posts covers the archive
+		// capability check regardless of post ownership, so the only thing
+		// under test is the attribution fallback, not a capability nuance.
+		const username = uniqueUsername( 'aps_e2e_doomed' );
+		const doomed = await requestUtils.createUser( {
+			username,
+			email: `${ username }@example.com`,
+			password: 'aps-e2e-doomed-password',
+			roles: [ 'administrator' ],
+		} );
+		createdUsers.push( doomed.id );
+
+		// --user gives the CLI request a real current-user context, so
+		// ArchiveMeta records THIS user's id rather than 0 (contrast the
+		// anonymous "system" test above, which omits --user entirely).
+		const cli = await wpCli( [
+			`--user=${ doomed.id }`,
+			'post',
+			'archive',
+			String( post.id ),
+		] );
+		expect( cli.exitCode ).toBe( 0 );
+
+		const archived = await postState( requestUtils, post.id );
+		expect( archived.post_status ).toBe( ARCHIVED_STATUS_SLUG );
+		expect( archived.meta.archive_user ).toBe( doomed.id );
+
+		// The archiving user's account no longer exists — get_userdata()
+		// must now fail where the "system" test's archive_user === 0 never
+		// even reaches it.
+		await requestUtils.rest( {
+			method: 'DELETE',
+			path: `/wp/v2/users/${ doomed.id }`,
+			params: { force: true, reassign: 1 },
+		} );
+
+		await admin.visitAdminPage( 'edit.php', ARCHIVED_VIEW );
+
+		const cell = rowLocator( page, post.id ).locator(
+			`td.column-${ COLUMN_KEY }`
+		);
+
+		await expect( cell ).toContainText(
+			strings.attribution_template.replace(
+				'%1$s',
+				strings.unknown_attribution
+			)
+		);
+		await expect( cell.locator( '.aps-archive-datetime' ) ).not.toBeEmpty();
+	} );
+
+	// A third, independent registration point: `manage_edit-{type}_sortable_columns`
+	// is what makes the header a clickable sort link at all — a type left
+	// off that loop while still getting the column and cell would render a
+	// plain (non-link) header, so `sortLink.click()` below would have
+	// nothing to click.
+	for ( const postType of POST_TYPES ) {
+		test( `${ postType.label }: the column sorts by archive date and the order flips on a second click`, async ( {
+			admin,
+			page,
+			requestUtils,
+		} ) => {
+			const older = await seedPost( requestUtils, {
+				title: uniqueTitle( `Column sort older ${ postType.key }` ),
+				status: 'publish',
+				type: postType.restBase,
+			} );
+			const newer = await seedPost( requestUtils, {
+				title: uniqueTitle( `Column sort newer ${ postType.key }` ),
+				status: 'publish',
+				type: postType.restBase,
+			} );
+			created.push(
+				{ id: older.id, type: postType.restBase },
+				{ id: newer.id, type: postType.restBase }
+			);
+
+			await archivePost( requestUtils, older.id );
+			await archivePost( requestUtils, newer.id );
+
+			await setArchiveMeta( requestUtils, older.id, {
+				archive_date: FIXED_TIMESTAMP,
+			} );
+			await setArchiveMeta( requestUtils, newer.id, {
+				archive_date: FIXED_TIMESTAMP + 3600,
+			} );
+
+			await admin.visitAdminPage(
+				'edit.php',
+				postListQuery( {
+					postType: postType.queryArg,
+					postStatus: ARCHIVED_STATUS_SLUG,
+				} )
+			);
+
+			const rowIds = async () =>
+				page
+					.locator( '#the-list tr' )
+					.evaluateAll( ( rows ) => rows.map( ( row ) => row.id ) );
+
+			const sortLink = page.locator( `th#${ COLUMN_KEY } a` );
+
+			await Promise.all( [
+				page.waitForURL( /orderby=aps_archived/ ),
+				sortLink.click(),
+			] );
+			expect( await rowIds() ).toEqual( [
+				`post-${ older.id }`,
+				`post-${ newer.id }`,
+			] );
+
+			await Promise.all( [
+				page.waitForURL( /order=desc/ ),
+				page.locator( `th#${ COLUMN_KEY } a` ).click(),
+			] );
+			expect( await rowIds() ).toEqual( [
+				`post-${ newer.id }`,
+				`post-${ older.id }`,
+			] );
+		} );
+	}
+} );

--- a/tests/e2e/specs/post-list/bulk-actions.spec.ts
+++ b/tests/e2e/specs/post-list/bulk-actions.spec.ts
@@ -1,0 +1,569 @@
+/**
+ * Pins the 0.4.0 bulk archive / unarchive flow.
+ *
+ * `Admin\BulkActionHandler` keeps going after a per-item failure and buckets the
+ * reason (`locked`, `denied`, `not_found`, `wrong_status`);
+ * `Admin\BulkActionResult` puts the counts on the redirect URL, including a
+ * single aggregate `skipped`; `Admin\NoticeBuilder` renders one line per bucket
+ * plus the success line with its Undo link.
+ *
+ * The `invalid` bucket was deleted in 0.4.0 — no notice and no query arg may
+ * reintroduce it.
+ *
+ * Counters are read off the redirect `Location` header rather than the address
+ * bar; see `applyBulkAction()` for why.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { test, expect } from '@wordpress/e2e-test-utils-playwright';
+
+/**
+ * External dependencies
+ */
+import type { Page } from '@playwright/test';
+
+/**
+ * Internal dependencies
+ */
+import { ARCHIVED_STATUS_SLUG } from '../../config/roles';
+import {
+	applyBulkAction,
+	noticeLocator,
+	noticeWith,
+	postListQuery,
+	selectRows,
+} from '../../config/admin';
+import {
+	FIXTURE_TOGGLES,
+	resetFixtures,
+	setFixtures,
+} from '../../config/fixtures';
+import {
+	archivePost,
+	deletePosts,
+	lockPost,
+	POST_TYPES,
+	postState,
+	roleUserIds,
+	seedPost,
+	uniqueTitle,
+} from '../../config/seed';
+import type { PostTypeUnderTest } from '../../config/seed';
+import { pluginStrings } from '../../config/strings';
+
+/**
+ * A post created during a test, tagged with the REST base `deletePosts()`
+ * needs to remove it again. The two tests that loop {@link POST_TYPES} seed
+ * more than one type into the same `created` array, so a single hardcoded
+ * base would silently fail to delete anything but `post`.
+ */
+interface CreatedPost {
+	id: number;
+	type: PostTypeUnderTest[ 'restBase' ];
+}
+
+/**
+ * Delete every tracked post, grouped by REST base.
+ *
+ * @param requestUtils Admin request utils.
+ * @param posts        Posts pushed onto the describe block's `created` array.
+ */
+async function deleteCreated(
+	requestUtils: Parameters< typeof deletePosts >[ 0 ],
+	posts: CreatedPost[]
+): Promise< void > {
+	await Promise.all(
+		POST_TYPES.map( ( { restBase } ) =>
+			deletePosts(
+				requestUtils,
+				posts
+					.filter( ( post ) => post.type === restBase )
+					.map( ( post ) => post.id ),
+				restBase
+			)
+		)
+	);
+}
+
+/**
+ * Assert that nothing reintroduces the `invalid` bucket deleted in 0.4.0.
+ *
+ * @param page   Page under test.
+ * @param params Redirect query args returned by the bulk action.
+ */
+async function expectNoInvalidBucket(
+	page: Page,
+	params: URLSearchParams
+): Promise< void > {
+	expect( params.has( 'invalid' ) ).toBe( false );
+	await expect( noticeWith( page, /invalid/i ) ).toHaveCount( 0 );
+}
+
+test.describe( 'post list: bulk actions', () => {
+	const created: CreatedPost[] = [];
+	let strings: Awaited< ReturnType< typeof pluginStrings > >;
+
+	test.beforeAll( async ( { requestUtils } ) => {
+		strings = await pluginStrings( requestUtils );
+	} );
+
+	test.afterEach( async ( { requestUtils } ) => {
+		await deleteCreated( requestUtils, created.splice( 0 ) );
+		await resetFixtures( requestUtils, [
+			FIXTURE_TOGGLES.deniedPostId,
+			FIXTURE_TOGGLES.restrictStatuses,
+		] );
+	} );
+
+	// The two tests below loop every {@link POST_TYPES} entry: both the
+	// dropdown option (`PostList::bulk_actions()`) and the handler
+	// (`BulkActionHandler::handle()`) are wired per post type via
+	// `bulk_actions-edit-{type}` / `handle_bulk_actions-edit-{type}`
+	// (src/Admin/PostList.php::hooks()) — a registration loop that only
+	// wired `post` would leave `page`/`book` with no bulk Archive/Unarchive
+	// option at all, or an option that silently does nothing on submit.
+	// Together the two tests exercise both directions of that wiring: this
+	// one covers the Archive branch (dropdown option + handler) plus Undo,
+	// which round-trips back through the Unarchive handler via a GET link
+	// rather than the dropdown.
+	for ( const postType of POST_TYPES ) {
+		test( `${ postType.label }: bulk Archive archives every selected post and offers Undo`, async ( {
+			admin,
+			page,
+			requestUtils,
+		} ) => {
+			const first = await seedPost( requestUtils, {
+				title: uniqueTitle( `Bulk archive one ${ postType.key }` ),
+				status: 'publish',
+				type: postType.restBase,
+			} );
+			const second = await seedPost( requestUtils, {
+				title: uniqueTitle( `Bulk archive two ${ postType.key }` ),
+				status: 'publish',
+				type: postType.restBase,
+			} );
+			created.push(
+				{ id: first.id, type: postType.restBase },
+				{ id: second.id, type: postType.restBase }
+			);
+
+			await admin.visitAdminPage(
+				'edit.php',
+				postListQuery( { postType: postType.queryArg } )
+			);
+			await selectRows( page, [ first.id, second.id ] );
+			const params = await applyBulkAction( page, 'archive' );
+
+			await expect(
+				noticeWith( page, strings.archived_notice_many )
+			).toBeVisible();
+			expect( params.get( 'archived' ) ).toBe( '2' );
+			// The form submits ids in list-table order, so compare as a set.
+			expect(
+				params.get( 'ids' )?.split( ',' ).map( Number ).sort()
+			).toEqual( [ first.id, second.id ].sort() );
+			expect( params.has( 'skipped' ) ).toBe( false );
+			await expectNoInvalidBucket( page, params );
+
+			for ( const id of [ first.id, second.id ] ) {
+				expect(
+					( await postState( requestUtils, id ) ).post_status
+				).toBe( ARCHIVED_STATUS_SLUG );
+			}
+
+			// Undo restores the status each post held before archiving.
+			const undo = noticeLocator( page ).getByRole( 'link', {
+				name: strings.undo_label,
+			} );
+			await expect( undo ).toBeVisible();
+
+			await Promise.all( [
+				page.waitForURL( /edit\.php/ ),
+				undo.click(),
+			] );
+
+			await expect(
+				noticeWith( page, strings.unarchived_notice_many )
+			).toBeVisible();
+
+			for ( const id of [ first.id, second.id ] ) {
+				expect(
+					( await postState( requestUtils, id ) ).post_status
+				).toBe( 'publish' );
+			}
+		} );
+	}
+
+	// The Unarchive-branch counterpart to the Archive test above: reaches
+	// the archived-view dropdown's Unarchive option directly (rather than
+	// Undo's GET link), and additionally pins that each post restores its
+	// OWN previous status rather than a shared default — a check that has
+	// nothing to do with post type but is cheap to keep per-type since the
+	// loop is already here for the wiring proof.
+	for ( const postType of POST_TYPES ) {
+		test( `${ postType.label }: bulk Unarchive restores every selected post`, async ( {
+			admin,
+			page,
+			requestUtils,
+		} ) => {
+			const published = await seedPost( requestUtils, {
+				title: uniqueTitle( `Bulk unarchive publish ${ postType.key }` ),
+				status: 'publish',
+				type: postType.restBase,
+			} );
+			const draft = await seedPost( requestUtils, {
+				title: uniqueTitle( `Bulk unarchive draft ${ postType.key }` ),
+				status: 'draft',
+				type: postType.restBase,
+			} );
+			created.push(
+				{ id: published.id, type: postType.restBase },
+				{ id: draft.id, type: postType.restBase }
+			);
+
+			await archivePost( requestUtils, published.id );
+			await archivePost( requestUtils, draft.id );
+
+			await admin.visitAdminPage(
+				'edit.php',
+				postListQuery( {
+					postType: postType.queryArg,
+					postStatus: ARCHIVED_STATUS_SLUG,
+				} )
+			);
+			await selectRows( page, [ published.id, draft.id ] );
+			const params = await applyBulkAction( page, 'unarchive' );
+
+			await expect(
+				noticeWith( page, strings.unarchived_notice_many )
+			).toBeVisible();
+			expect( params.get( 'unarchived' ) ).toBe( '2' );
+			await expectNoInvalidBucket( page, params );
+
+			// Each post returns to its own previous status, not a shared default.
+			expect(
+				( await postState( requestUtils, published.id ) ).post_status
+			).toBe( 'publish' );
+			expect(
+				( await postState( requestUtils, draft.id ) ).post_status
+			).toBe( 'draft' );
+		} );
+	}
+
+	// Deliberately NOT parameterized over POST_TYPES from here down: every
+	// bucket below (locked / denied / wrong_status / the aggregate) is
+	// decided by BulkActionHandler::process_archive_post() /
+	// process_unarchive_post(), and neither branches on post type —
+	// wp_check_post_lock(), ArchiveCapability::can_archive(),
+	// get_post_status() and ArchivableStatuses::includes() all take a bare
+	// post id, nothing type-shaped. The one thing that DOES vary per type —
+	// whether handle_bulk_actions-edit-{type} is wired at all — is already
+	// proven by the two loops above, which exercise both the Archive and
+	// Unarchive branches for every {@link POST_TYPES} entry. Looping the
+	// bucket tests too would re-prove that same wiring three more times per
+	// test for no additional signal.
+	test( 'a post locked by another user lands in the locked bucket', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		const free = await seedPost( requestUtils, {
+			title: uniqueTitle( 'Bulk lock free' ),
+			status: 'publish',
+		} );
+		const locked = await seedPost( requestUtils, {
+			title: uniqueTitle( 'Bulk lock held' ),
+			status: 'publish',
+		} );
+		created.push(
+			{ id: free.id, type: 'posts' },
+			{ id: locked.id, type: 'posts' }
+		);
+
+		const users = await roleUserIds( requestUtils );
+
+		await admin.visitAdminPage( 'edit.php', postListQuery() );
+		await selectRows( page, [ free.id, locked.id ] );
+
+		// Lock after selecting: core hides the checkbox on rows it already
+		// renders as locked, and "somebody started editing between select and
+		// apply" is the race this bucket exists for.
+		await lockPost( requestUtils, locked.id, users.aps_editor );
+
+		const params = await applyBulkAction( page, 'archive' );
+
+		await expect(
+			noticeWith( page, strings.archived_notice_one )
+		).toBeVisible();
+		await expect(
+			noticeWith( page, strings.locked_notice_one )
+		).toBeVisible();
+		expect( params.get( 'archived' ) ).toBe( '1' );
+		expect( params.get( 'locked' ) ).toBe( '1' );
+		expect( params.get( 'skipped' ) ).toBe( '1' );
+		await expectNoInvalidBucket( page, params );
+
+		expect( ( await postState( requestUtils, free.id ) ).post_status ).toBe(
+			ARCHIVED_STATUS_SLUG
+		);
+		expect(
+			( await postState( requestUtils, locked.id ) ).post_status
+		).toBe( 'publish' );
+	} );
+
+	test( 'a post the user cannot archive lands in the denied bucket', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		const allowed = await seedPost( requestUtils, {
+			title: uniqueTitle( 'Bulk denied allowed' ),
+			status: 'publish',
+		} );
+		const denied = await seedPost( requestUtils, {
+			title: uniqueTitle( 'Bulk denied blocked' ),
+			status: 'publish',
+		} );
+		created.push(
+			{ id: allowed.id, type: 'posts' },
+			{ id: denied.id, type: 'posts' }
+		);
+
+		// Per-post denial: the screen-level gate in BulkActionHandler::handle()
+		// still passes, so the batch runs and exactly one item is skipped.
+		await setFixtures( requestUtils, {
+			[ FIXTURE_TOGGLES.deniedPostId ]: denied.id,
+		} );
+
+		await admin.visitAdminPage( 'edit.php', postListQuery() );
+		await selectRows( page, [ allowed.id, denied.id ] );
+		const params = await applyBulkAction( page, 'archive' );
+
+		await expect(
+			noticeWith( page, strings.archived_notice_one )
+		).toBeVisible();
+		await expect(
+			noticeWith( page, strings.denied_notice_one )
+		).toBeVisible();
+		expect( params.get( 'archived' ) ).toBe( '1' );
+		expect( params.get( 'denied' ) ).toBe( '1' );
+		expect( params.get( 'skipped' ) ).toBe( '1' );
+		await expectNoInvalidBucket( page, params );
+
+		expect(
+			( await postState( requestUtils, allowed.id ) ).post_status
+		).toBe( ARCHIVED_STATUS_SLUG );
+		expect(
+			( await postState( requestUtils, denied.id ) ).post_status
+		).toBe( 'publish' );
+	} );
+
+	test( 'a post whose status is not archivable lands in the wrong_status bucket', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		const published = await seedPost( requestUtils, {
+			title: uniqueTitle( 'Bulk status publish' ),
+			status: 'publish',
+		} );
+		const draft = await seedPost( requestUtils, {
+			title: uniqueTitle( 'Bulk status draft' ),
+			status: 'draft',
+		} );
+		created.push(
+			{ id: published.id, type: 'posts' },
+			{ id: draft.id, type: 'posts' }
+		);
+
+		// `aps_archivable_statuses` narrowed to publish only.
+		await setFixtures( requestUtils, {
+			[ FIXTURE_TOGGLES.restrictStatuses ]: true,
+		} );
+
+		await admin.visitAdminPage( 'edit.php', postListQuery() );
+		await selectRows( page, [ published.id, draft.id ] );
+		const params = await applyBulkAction( page, 'archive' );
+
+		await expect(
+			noticeWith( page, strings.archived_notice_one )
+		).toBeVisible();
+		await expect(
+			noticeWith( page, strings.wrong_status_notice_one )
+		).toBeVisible();
+		expect( params.get( 'archived' ) ).toBe( '1' );
+		expect( params.get( 'wrong_status' ) ).toBe( '1' );
+		expect( params.get( 'skipped' ) ).toBe( '1' );
+		await expectNoInvalidBucket( page, params );
+
+		expect(
+			( await postState( requestUtils, draft.id ) ).post_status
+		).toBe( 'draft' );
+	} );
+
+	test( 'the aggregate skipped count is the sum of every bucket', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		const ok = await seedPost( requestUtils, {
+			title: uniqueTitle( 'Bulk mixed ok' ),
+			status: 'publish',
+		} );
+		const locked = await seedPost( requestUtils, {
+			title: uniqueTitle( 'Bulk mixed locked' ),
+			status: 'publish',
+		} );
+		const denied = await seedPost( requestUtils, {
+			title: uniqueTitle( 'Bulk mixed denied' ),
+			status: 'publish',
+		} );
+		const missing = await seedPost( requestUtils, {
+			title: uniqueTitle( 'Bulk mixed missing' ),
+			status: 'publish',
+		} );
+		created.push(
+			{ id: ok.id, type: 'posts' },
+			{ id: locked.id, type: 'posts' },
+			{ id: denied.id, type: 'posts' }
+		);
+
+		const users = await roleUserIds( requestUtils );
+		await setFixtures( requestUtils, {
+			[ FIXTURE_TOGGLES.deniedPostId ]: denied.id,
+		} );
+
+		await admin.visitAdminPage( 'edit.php', postListQuery() );
+		await selectRows( page, [ ok.id, locked.id, denied.id, missing.id ] );
+
+		// Both mutations land after the checkboxes are ticked: the form still
+		// submits the ids, which is exactly the "state changed between select
+		// and dispatch" case these buckets exist for.
+		await lockPost( requestUtils, locked.id, users.aps_editor );
+		await deletePosts( requestUtils, [ missing.id ] );
+
+		const params = await applyBulkAction( page, 'archive' );
+
+		expect( params.get( 'archived' ) ).toBe( '1' );
+		expect( params.get( 'locked' ) ).toBe( '1' );
+		expect( params.get( 'denied' ) ).toBe( '1' );
+		expect( params.get( 'not_found' ) ).toBe( '1' );
+		expect( params.get( 'skipped' ) ).toBe( '3' );
+		expect( params.get( 'wrong_status' ) ).toBeNull();
+
+		await expect(
+			noticeWith( page, strings.locked_notice_one )
+		).toBeVisible();
+		await expect(
+			noticeWith( page, strings.denied_notice_one )
+		).toBeVisible();
+		await expect(
+			noticeWith( page, strings.not_found_notice_one )
+		).toBeVisible();
+		await expectNoInvalidBucket( page, params );
+	} );
+
+	// The Undo tests in the per-post-type loop at the top of this file only
+	// exercise an all-succeeded batch. `BulkActionResult::record()` — the
+	// only method that appends to the id list the Undo link is built from —
+	// is called exclusively on the success path; every skip bucket
+	// (`record_denied()`, `record_locked()`, etc.) deliberately does not
+	// touch it. This test pins that contract end to end: a batch with one
+	// skipped item must produce an Undo link carrying ONLY the ids that
+	// were actually archived, and clicking it must reverse only those.
+	test( 'Undo after a mixed batch restores only the items that were actually archived', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		const first = await seedPost( requestUtils, {
+			title: uniqueTitle( 'Bulk undo mixed first' ),
+			status: 'publish',
+		} );
+		const second = await seedPost( requestUtils, {
+			title: uniqueTitle( 'Bulk undo mixed second' ),
+			status: 'publish',
+		} );
+		const denied = await seedPost( requestUtils, {
+			title: uniqueTitle( 'Bulk undo mixed denied' ),
+			status: 'publish',
+		} );
+		created.push(
+			{ id: first.id, type: 'posts' },
+			{ id: second.id, type: 'posts' },
+			{ id: denied.id, type: 'posts' }
+		);
+
+		// Per-post denial: the screen-level gate still passes, so the batch
+		// runs and exactly one of the three selected items is skipped.
+		await setFixtures( requestUtils, {
+			[ FIXTURE_TOGGLES.deniedPostId ]: denied.id,
+		} );
+
+		await admin.visitAdminPage( 'edit.php', postListQuery() );
+		await selectRows( page, [ first.id, second.id, denied.id ] );
+		const params = await applyBulkAction( page, 'archive' );
+
+		expect( params.get( 'archived' ) ).toBe( '2' );
+		expect( params.get( 'denied' ) ).toBe( '1' );
+		expect( params.get( 'skipped' ) ).toBe( '1' );
+
+		expect(
+			( await postState( requestUtils, first.id ) ).post_status
+		).toBe( ARCHIVED_STATUS_SLUG );
+		expect(
+			( await postState( requestUtils, second.id ) ).post_status
+		).toBe( ARCHIVED_STATUS_SLUG );
+		expect(
+			( await postState( requestUtils, denied.id ) ).post_status
+		).toBe( 'publish' );
+
+		const undo = noticeLocator( page ).getByRole( 'link', {
+			name: strings.undo_label,
+		} );
+		await expect( undo ).toBeVisible();
+
+		// Read the Undo link's own `ids` before clicking it: the denied
+		// post's id must never appear here, regardless of what clicking the
+		// link goes on to do.
+		const undoHref = await undo.getAttribute( 'href' );
+		if ( ! undoHref ) {
+			throw new Error( 'The Undo link had no href.' );
+		}
+		const idsParam = new URL( undoHref, page.url() ).searchParams.get(
+			'ids'
+		);
+		if ( ! idsParam ) {
+			throw new Error( 'The Undo link had no "ids" query arg.' );
+		}
+		const undoIds = idsParam
+			.split( ',' )
+			.map( Number )
+			.sort( ( a, b ) => a - b );
+		expect( undoIds ).toEqual(
+			[ first.id, second.id ].sort( ( a, b ) => a - b )
+		);
+
+		await Promise.all( [ page.waitForURL( /edit\.php/ ), undo.click() ] );
+
+		await expect(
+			noticeWith( page, strings.unarchived_notice_many )
+		).toBeVisible();
+
+		// Undo reversed exactly the two posts it archived...
+		expect(
+			( await postState( requestUtils, first.id ) ).post_status
+		).toBe( 'publish' );
+		expect(
+			( await postState( requestUtils, second.id ) ).post_status
+		).toBe( 'publish' );
+
+		// ...and the skipped post is exactly where the failed archive
+		// attempt left it — never touched by the archive OR by Undo.
+		expect(
+			( await postState( requestUtils, denied.id ) ).post_status
+		).toBe( 'publish' );
+	} );
+} );

--- a/tests/e2e/specs/post-list/quick-edit.spec.ts
+++ b/tests/e2e/specs/post-list/quick-edit.spec.ts
@@ -1,0 +1,126 @@
+/**
+ * The Quick Edit journey against the real inline-edit row.
+ *
+ * 0.4.0 removed the 0.3.x status-dropdown injection: archiving happens
+ * through row/bulk actions and the editor button, never through Quick
+ * Edit's status select. Both directions are pinned here — the select on an
+ * archivable post offers no archived option, and an archived row offers no
+ * Quick Edit at all.
+ *
+ * Neither test loops {@link POST_TYPES}: for both, no per-type registration
+ * in this plugin gates the observed behaviour, so there is no per-type
+ * mutation a registration-loop bug could produce.
+ *
+ *   - The status select: WordPress core builds `<select name="_status">`'s
+ *     option list itself (`WP_Posts_List_Table::inline_edit()` in
+ *     wp-admin/includes/class-wp-posts-list-table.php), independent of
+ *     `register_post_status()`'s args, and nothing in `src/` hooks the
+ *     `quick_edit_statuses` filter (or the legacy `quick_edit_custom_box` /
+ *     `bulk_edit_custom_box`) for any post type — confirmed by grep. There
+ *     is no plugin-owned code path here, per-type or otherwise, to break.
+ *   - The Quick Edit trigger: core only adds the `'inline hide-if-no-js'`
+ *     row action (the `button.editinline` this test looks for) when
+ *     `current_user_can( 'edit_post', ... )` is true (same file,
+ *     `handle_row_actions()`). `PostEditorGuard::deny_editing_archived()`
+ *     denies that capability for every archived post while read-only mode
+ *     is active — this suite's stock default, unset by any test here — via
+ *     a `map_meta_cap` filter keyed only on post status, never post type.
+ *     Core itself withholds the button before `RowActionPolicy`'s own
+ *     per-type-gated removal of the same action ever gets a chance to
+ *     matter — the same "core gate front-runs the plugin check" trap that
+ *     defeated the original, unparameterized capability-matrix sweep.
+ *     Confirmed by mutating `PostList::hooks()`'s per-type loop to wire
+ *     `post` only and re-running this exact check against an archived
+ *     `page`: `button.editinline` stayed absent (0) both before and after
+ *     the mutation, while the row's Unarchive link — genuinely gated by
+ *     that same loop — dropped from 1 to 0. See the task report for the
+ *     full mutation results.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { test, expect } from '@wordpress/e2e-test-utils-playwright';
+
+/**
+ * Internal dependencies
+ */
+import { ARCHIVED_STATUS_SLUG } from '../../config/roles';
+import { postListQuery, rowLocator } from '../../config/admin';
+import {
+	archivePost,
+	deletePosts,
+	seedPost,
+	uniqueTitle,
+} from '../../config/seed';
+
+test.describe( 'post list: Quick Edit', () => {
+	const created: number[] = [];
+
+	test.afterEach( async ( { requestUtils } ) => {
+		await deletePosts( requestUtils, created.splice( 0 ) );
+	} );
+
+	test( 'the status select offers no archived option for an archivable post', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		const post = await seedPost( requestUtils, {
+			title: uniqueTitle( 'Quick edit archivable' ),
+			status: 'publish',
+		} );
+		created.push( post.id );
+
+		await admin.visitAdminPage( 'edit.php', postListQuery() );
+
+		const row = rowLocator( page, post.id );
+		await expect( row ).toBeVisible();
+
+		// Row actions are revealed on hover; the Quick Edit trigger is the
+		// core .editinline button.
+		await row.hover();
+		await row.locator( 'button.editinline' ).click();
+
+		const inlineRow = page.locator( `#edit-${ post.id }` );
+		await expect( inlineRow ).toBeVisible();
+
+		const statusSelect = inlineRow.locator( 'select[name="_status"]' );
+		await expect( statusSelect ).toBeVisible();
+
+		const values = await statusSelect
+			.locator( 'option' )
+			.evaluateAll( ( options ) =>
+				options.map( ( option ) => option.getAttribute( 'value' ) )
+			);
+		expect( values.length ).toBeGreaterThan( 0 );
+		expect( values ).not.toContain( ARCHIVED_STATUS_SLUG );
+
+		await inlineRow.locator( 'button.cancel' ).click();
+		await expect( inlineRow ).toBeHidden();
+	} );
+
+	test( 'an archived row exposes no Quick Edit trigger', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		const post = await seedPost( requestUtils, {
+			title: uniqueTitle( 'Quick edit archived' ),
+			status: 'publish',
+		} );
+		created.push( post.id );
+		await archivePost( requestUtils, post.id );
+
+		await admin.visitAdminPage(
+			'edit.php',
+			postListQuery( { postStatus: ARCHIVED_STATUS_SLUG } )
+		);
+
+		const row = rowLocator( page, post.id );
+		await expect( row ).toBeVisible();
+
+		await row.hover();
+		await expect( row.locator( 'button.editinline' ) ).toHaveCount( 0 );
+	} );
+} );

--- a/tests/e2e/specs/post-list/row-actions.spec.ts
+++ b/tests/e2e/specs/post-list/row-actions.spec.ts
@@ -1,0 +1,281 @@
+/**
+ * Pins the inline row actions added by `Admin\RowActionPolicy`.
+ *
+ * Archivable rows offer Archive, archived rows offer Unarchive, each action
+ * performs the transition and lands back on the list table, and archived rows
+ * lose the row actions that do not apply to read-only content.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { test, expect } from '@wordpress/e2e-test-utils-playwright';
+
+/**
+ * Internal dependencies
+ */
+import { ARCHIVED_STATUS_SLUG } from '../../config/roles';
+import {
+	noticeWith,
+	postListQuery,
+	rowActionLocator,
+	rowLocator,
+} from '../../config/admin';
+import {
+	archivePost,
+	deletePosts,
+	POST_TYPES,
+	postState,
+	seedPost,
+	uniqueTitle,
+} from '../../config/seed';
+import type { PostTypeUnderTest } from '../../config/seed';
+import { pluginStrings } from '../../config/strings';
+
+/**
+ * A post created during a test, tagged with the REST base `deletePosts()`
+ * needs to remove it again. Several tests below loop {@link POST_TYPES},
+ * seeding more than one type into the same `created` array, so a single
+ * hardcoded base would silently fail to delete anything but `post`.
+ */
+interface CreatedPost {
+	id: number;
+	type: PostTypeUnderTest[ 'restBase' ];
+}
+
+/**
+ * Delete every tracked post, grouped by REST base.
+ *
+ * @param requestUtils Admin request utils.
+ * @param posts        Posts pushed onto the describe block's `created` array.
+ */
+async function deleteCreated(
+	requestUtils: Parameters< typeof deletePosts >[ 0 ],
+	posts: CreatedPost[]
+): Promise< void > {
+	await Promise.all(
+		POST_TYPES.map( ( { restBase } ) =>
+			deletePosts(
+				requestUtils,
+				posts
+					.filter( ( post ) => post.type === restBase )
+					.map( ( post ) => post.id ),
+				restBase
+			)
+		)
+	);
+}
+
+/**
+ * Reveal a row's action links, which the list table keeps off-screen until the
+ * row is hovered, then click one.
+ *
+ * @param page   Page under test.
+ * @param id     Post id.
+ * @param action Row action key.
+ */
+async function clickRowAction(
+	page: import('@playwright/test').Page,
+	id: number,
+	action: string
+): Promise< void > {
+	await rowLocator( page, id ).hover();
+	await Promise.all( [
+		page.waitForURL( /edit\.php/ ),
+		rowActionLocator( page, id, action ).click(),
+	] );
+}
+
+test.describe( 'post list: row actions', () => {
+	const created: CreatedPost[] = [];
+	let strings: Awaited< ReturnType< typeof pluginStrings > >;
+
+	test.beforeAll( async ( { requestUtils } ) => {
+		strings = await pluginStrings( requestUtils );
+	} );
+
+	test.afterEach( async ( { requestUtils } ) => {
+		await deleteCreated( requestUtils, created.splice( 0 ) );
+	} );
+
+	// The four tests below loop every {@link POST_TYPES} entry: the Archive /
+	// Unarchive row action links only exist because
+	// `RowActionPolicy::for_post()` is wired per post type via the
+	// `{type}_row_actions` filter (src/Admin/PostList.php::hooks()) — a
+	// registration loop that only wired `post` would leave `page`/`book`
+	// rows with no Archive/Unarchive link at all. Confirmed observable by
+	// mutating that loop directly: `page`'s Unarchive link disappeared while
+	// `post`'s did not (see the task report for the mutation results). The
+	// Edit / Quick Edit absence asserted inside the third test below is
+	// NOT part of that signal — core withholds both unconditionally once
+	// PostEditorGuard denies `edit_post` for any archived post (read-only
+	// mode, the suite's stock default), regardless of whether
+	// `{type}_row_actions` ever runs. They stay asserted because they are
+	// still true and worth pinning; the per-type coverage in this describe
+	// block comes from the archive/unarchive assertions.
+	for ( const postType of POST_TYPES ) {
+		test( `${ postType.label }: the Archive row action archives the post and returns to the list`, async ( {
+			admin,
+			page,
+			requestUtils,
+		} ) => {
+			const title = uniqueTitle( `Row archive ${ postType.key }` );
+			const post = await seedPost( requestUtils, {
+				title,
+				status: 'publish',
+				type: postType.restBase,
+			} );
+			created.push( { id: post.id, type: postType.restBase } );
+
+			await admin.visitAdminPage(
+				'edit.php',
+				postListQuery( { postType: postType.queryArg } )
+			);
+
+			const action = rowActionLocator( page, post.id, 'archive' );
+			await expect( action ).toHaveText( strings.archive_row_action );
+
+			await clickRowAction( page, post.id, 'archive' );
+
+			await expect(
+				noticeWith( page, strings.archived_notice_one )
+			).toBeVisible();
+			expect(
+				( await postState( requestUtils, post.id ) ).post_status
+			).toBe( ARCHIVED_STATUS_SLUG );
+		} );
+	}
+
+	for ( const postType of POST_TYPES ) {
+		test( `${ postType.label }: the Unarchive row action restores the previous status`, async ( {
+			admin,
+			page,
+			requestUtils,
+		} ) => {
+			const post = await seedPost( requestUtils, {
+				title: uniqueTitle( `Row unarchive ${ postType.key }` ),
+				status: 'publish',
+				type: postType.restBase,
+			} );
+			created.push( { id: post.id, type: postType.restBase } );
+			await archivePost( requestUtils, post.id );
+
+			await admin.visitAdminPage(
+				'edit.php',
+				postListQuery( {
+					postType: postType.queryArg,
+					postStatus: ARCHIVED_STATUS_SLUG,
+				} )
+			);
+
+			const action = rowActionLocator( page, post.id, 'unarchive' );
+			await expect( action ).toHaveText( strings.unarchive_row_action );
+
+			await clickRowAction( page, post.id, 'unarchive' );
+
+			await expect(
+				noticeWith( page, strings.unarchived_notice_one )
+			).toBeVisible();
+			expect(
+				( await postState( requestUtils, post.id ) ).post_status
+			).toBe( 'publish' );
+		} );
+	}
+
+	for ( const postType of POST_TYPES ) {
+		test( `${ postType.label }: an archived row offers Unarchive but not Archive, Edit or Quick Edit`, async ( {
+			admin,
+			page,
+			requestUtils,
+		} ) => {
+			const post = await seedPost( requestUtils, {
+				title: uniqueTitle( `Row actions removed ${ postType.key }` ),
+				status: 'publish',
+				type: postType.restBase,
+			} );
+			created.push( { id: post.id, type: postType.restBase } );
+			await archivePost( requestUtils, post.id );
+
+			await admin.visitAdminPage(
+				'edit.php',
+				postListQuery( {
+					postType: postType.queryArg,
+					postStatus: ARCHIVED_STATUS_SLUG,
+				} )
+			);
+
+			const row = rowLocator( page, post.id );
+			await expect( row ).toBeVisible();
+
+			await expect(
+				rowActionLocator( page, post.id, 'unarchive' )
+			).toHaveCount( 1 );
+			await expect(
+				rowActionLocator( page, post.id, 'archive' )
+			).toHaveCount( 0 );
+			await expect( row.locator( '.row-actions .edit' ) ).toHaveCount(
+				0
+			);
+			await expect(
+				row.locator( '.row-actions .inline' )
+			).toHaveCount( 0 );
+		} );
+	}
+
+	for ( const postType of POST_TYPES ) {
+		test( `${ postType.label }: an archivable row offers Archive but not Unarchive`, async ( {
+			admin,
+			page,
+			requestUtils,
+		} ) => {
+			const post = await seedPost( requestUtils, {
+				title: uniqueTitle( `Row draft actions ${ postType.key }` ),
+				status: 'draft',
+				type: postType.restBase,
+			} );
+			created.push( { id: post.id, type: postType.restBase } );
+
+			await admin.visitAdminPage(
+				'edit.php',
+				postListQuery( { postType: postType.queryArg } )
+			);
+
+			await expect(
+				rowActionLocator( page, post.id, 'archive' )
+			).toHaveCount( 1 );
+			await expect(
+				rowActionLocator( page, post.id, 'unarchive' )
+			).toHaveCount( 0 );
+			// Editing an unarchived post is untouched by the plugin.
+			await expect(
+				rowLocator( page, post.id ).locator( '.row-actions .edit' )
+			).toHaveCount( 1 );
+		} );
+	}
+
+	// Deliberately NOT parameterized over POST_TYPES: the "All" view
+	// exclusion comes from register_post_status()'s single
+	// `show_in_admin_all_list` arg (src/Status/PostStatus.php::status_args()),
+	// registered ONCE for every supported post type in one
+	// register_post_status() call (`'post_type' => aps_get_supported_post_types()`)
+	// — there is no per-type hook here for a registration-loop bug to break.
+	test( 'archived posts are hidden from the All view', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		const post = await seedPost( requestUtils, {
+			title: uniqueTitle( 'Hidden from all' ),
+			status: 'publish',
+		} );
+		created.push( { id: post.id, type: 'posts' } );
+
+		await admin.visitAdminPage( 'edit.php', postListQuery() );
+		await expect( rowLocator( page, post.id ) ).toBeVisible();
+
+		await archivePost( requestUtils, post.id );
+
+		await admin.visitAdminPage( 'edit.php', postListQuery() );
+		await expect( rowLocator( page, post.id ) ).toHaveCount( 0 );
+	} );
+} );

--- a/tests/e2e/specs/roles/capability-matrix.spec.ts
+++ b/tests/e2e/specs/roles/capability-matrix.spec.ts
@@ -1,0 +1,783 @@
+/**
+ * The capability matrix: role x action, asserted in BOTH directions.
+ *
+ * This is the class of bug the PHP unit suite cannot see — a capability that is
+ * resolved correctly in isolation but never actually enforced at the surface a
+ * user touches. Every case below therefore drives the real screen or the real
+ * URL as the role in question.
+ *
+ * Defaults under test (`Archive\ViewCapability`, `Archive\ArchiveCapability`)
+ * are ownership-aware: a post's own author passes via the post type's
+ * `edit_posts` primitive; anyone else needs its `edit_others_posts` (archive /
+ * unarchive) or `read_private_posts` (view). The matrix seeds each role's
+ * posts AS that role, so the author row exercises the own-content grants;
+ * the dedicated describe below it pins the other-authors denial.
+ *
+ * Capability-outcome cases (view / row actions / the bulk checkbox) run
+ * against every {@link POST_TYPES} entry. `page` surfaces a real WordPress
+ * difference along the way: the stock Author role holds no Page capability
+ * at all (core's `populate_roles()` gives Page capabilities to Editor and
+ * Administrator only), so `expectedFor()` below overrides the author row for
+ * `page` rather than assuming MATRIX applies uniformly — and the author's
+ * `edit.php?post_type=page` describe-block tests are skipped for the same
+ * reason, with a comment at each. Cases that never reach a post-type
+ * primitive (the read-only editor lockout, the anonymous view check, the
+ * capability-filter boundary tests) stay on a single post type — see the
+ * comment at each for why.
+ *
+ * The next-to-last describe re-runs the archive axis with
+ * `aps_default_archive_capability` and `aps_default_unarchive_capability`
+ * filtered to `manage_options`, which is the boundary-move scenario: the
+ * filter must actually move the boundary, not just be consulted. The last
+ * describe repeats that scenario for `aps_default_read_capability` alone:
+ * `RowActionPolicy::for_post()` strips the `view` row action when a user can
+ * unarchive a post but not view it, a combination stock roles never produce
+ * (every stock role holding `edit_others_posts` also holds
+ * `read_private_posts`).
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { test, expect } from '@wordpress/e2e-test-utils-playwright';
+
+/**
+ * Internal dependencies
+ */
+import {
+	ARCHIVED_STATUS_SLUG,
+	ROLE_USERS,
+	storageStatePath,
+} from '../../config/roles';
+import {
+	editUrl,
+	POST_TITLE,
+	postListQuery,
+	rowActionLocator,
+	rowCheckboxLocator,
+	rowLocator,
+} from '../../config/admin';
+import {
+	FIXTURE_TOGGLES,
+	resetFixtures,
+	setFixtures,
+} from '../../config/fixtures';
+import {
+	archivePost,
+	deletePosts,
+	POST_TYPES,
+	roleUserIds,
+	seedPost,
+	uniqueTitle,
+} from '../../config/seed';
+import type { PostTypeUnderTest } from '../../config/seed';
+import { pluginStrings } from '../../config/strings';
+
+let READ_ONLY_MESSAGE: string;
+
+test.beforeAll( async ( { requestUtils } ) => {
+	( { read_only_message: READ_ONLY_MESSAGE } = await pluginStrings(
+		requestUtils
+	) );
+} );
+
+/**
+ * Expected answers per role, for a post the role authored itself.
+ *
+ * `listsPosts` is core's own `edit_posts` gate, included so the subscriber row
+ * asserts the "cannot even get to the screen" direction rather than silently
+ * skipping.
+ *
+ * Uniform across {@link POST_TYPES} with one exception — see `expectedFor()`.
+ */
+const MATRIX = {
+	administrator: { canView: true, canArchive: true, listsPosts: true },
+	editor: { canView: true, canArchive: true, listsPosts: true },
+	author: { canView: true, canArchive: true, listsPosts: true },
+	subscriber: { canView: false, canArchive: false, listsPosts: false },
+} as const;
+
+type MatrixRole = keyof typeof MATRIX;
+
+/**
+ * A MATRIX cell shape, widened off the `as const` literals so `expectedFor()`
+ * can return either a matrix row or a computed override.
+ */
+interface MatrixExpectation {
+	canView: boolean;
+	canArchive: boolean;
+	listsPosts: boolean;
+}
+
+/**
+ * Resolve the expected matrix cell for a role x post type combination.
+ *
+ * Uniform across post types, with one exception: WordPress's stock Author
+ * role (`populate_roles()`) is never granted any Page capability at all —
+ * `edit_pages` and friends are Editor+ only — so an author has no more
+ * standing over a page than a subscriber does. `post` gives the author role
+ * `edit_posts` on their own content, and the `aps_book` fixture deliberately
+ * grants the `book`-equivalent (see `tests/e2e/fixtures/aps-cpt.php`), so
+ * `post` and `book` both match `MATRIX` unmodified; only `author` x `page`
+ * diverges.
+ *
+ * @param role     Role under test.
+ * @param postType Post type under test.
+ */
+function expectedFor(
+	role: MatrixRole,
+	postType: PostTypeUnderTest
+): MatrixExpectation {
+	if ( 'author' === role && 'page' === postType.key ) {
+		return { canView: false, canArchive: false, listsPosts: false };
+	}
+
+	return MATRIX[ role ];
+}
+
+/**
+ * The `wp_die()` copy shown when a role cannot reach a post type's list
+ * screen (the `! expected.listsPosts` branch below).
+ *
+ * Normally WordPress's own admin-menu gate
+ * (`user_can_access_admin_page()` in `wp-admin/includes/menu.php`) blocks the
+ * request before `edit.php` ever runs its own checks, producing the generic
+ * message — that gate is keyed off `$pagenow` (`edit.php`), not the
+ * `post_type` query arg, so it cannot tell Posts and Pages apart. The one
+ * combination under test where that matters: the author role holds
+ * `edit_posts`, which gives it a real `edit.php` menu entry (for Posts), so
+ * it clears this coarse, type-blind gate for `page` too — then `edit.php`'s
+ * own `current_user_can( $post_type_object->cap->edit_posts )` check, which
+ * IS type-aware, stops it a moment later with its own distinct copy.
+ *
+ * @param role     Role under test.
+ * @param postType Post type under test.
+ */
+function deniedScreenMessage(
+	role: MatrixRole,
+	postType: PostTypeUnderTest
+): string {
+	if ( 'author' === role && 'page' === postType.key ) {
+		return 'Sorry, you are not allowed to edit posts in this post type.';
+	}
+
+	return 'Sorry, you are not allowed to access this page.';
+}
+
+/**
+ * Explain why a screen-dependent "author acting on another author's content"
+ * test is skipped for `page` — the author cannot reach that type's list
+ * screen at all, so there is no "reaches the list, denied per-row" scenario
+ * left to assert.
+ *
+ * @param postType Post type under test.
+ */
+function authorUnreachableReason( postType: PostTypeUnderTest ): string {
+	return (
+		'the stock Author role holds no Page capability at all, so the ' +
+		'author cannot reach ' +
+		`edit.php?post_type=${ postType.queryArg } in the first place — ` +
+		"that blanket denial is already pinned by the MATRIX role loop's " +
+		"author x page case."
+	);
+}
+
+/**
+ * Resolve the user id a role's seeded content should be authored by.
+ *
+ * Posts are authored by the role under test so the author row exercises "my own
+ * post", which is the only case where an author has any standing at all.
+ *
+ * @param requestUtils Admin request utils.
+ * @param role         Role under test.
+ */
+async function authorIdFor(
+	requestUtils: Parameters< typeof roleUserIds >[ 0 ],
+	role: MatrixRole
+): Promise< number > {
+	if ( 'administrator' === role ) {
+		return 1;
+	}
+
+	const users = await roleUserIds( requestUtils );
+
+	return users[ ROLE_USERS[ role ].username ];
+}
+
+/**
+ * A post created during a test, tagged with the REST base `deletePosts()`
+ * needs to remove it again. A describe block that loops `POST_TYPES` seeds
+ * more than one type into the same `created` array, so a single hardcoded
+ * base would silently fail to delete anything but `post`.
+ */
+interface CreatedPost {
+	id: number;
+	type: PostTypeUnderTest[ 'restBase' ];
+}
+
+/**
+ * Delete every tracked post, grouped by REST base.
+ *
+ * @param requestUtils Admin request utils.
+ * @param posts        Posts pushed onto a describe block's `created` array.
+ */
+async function deleteCreated(
+	requestUtils: Parameters< typeof deletePosts >[ 0 ],
+	posts: CreatedPost[]
+): Promise< void > {
+	await Promise.all(
+		POST_TYPES.map( ( { restBase } ) =>
+			deletePosts(
+				requestUtils,
+				posts
+					.filter( ( post ) => post.type === restBase )
+					.map( ( post ) => post.id ),
+				restBase
+			)
+		)
+	);
+}
+
+for ( const role of Object.keys( MATRIX ) as MatrixRole[] ) {
+	test.describe( `roles: ${ role }`, () => {
+		test.use( { storageState: storageStatePath( role ) } );
+
+		const created: CreatedPost[] = [];
+
+		test.afterEach( async ( { requestUtils } ) => {
+			await deleteCreated( requestUtils, created.splice( 0 ) );
+		} );
+
+		for ( const postType of POST_TYPES ) {
+			const expected = expectedFor( role, postType );
+
+			test( `${ postType.label }: can${
+				expected.canView ? '' : 'not'
+			} view an archived post on the front end`, async ( {
+				page,
+				requestUtils,
+			} ) => {
+				const title = uniqueTitle(
+					`Matrix view ${ role } ${ postType.key }`
+				);
+				const post = await seedPost( requestUtils, {
+					title,
+					status: 'publish',
+					type: postType.restBase,
+					author: await authorIdFor( requestUtils, role ),
+				} );
+				created.push( { id: post.id, type: postType.restBase } );
+
+				const archived = await archivePost( requestUtils, post.id );
+				const response = await page.goto( archived.link );
+
+				if ( expected.canView ) {
+					expect( response?.status() ).toBe( 200 );
+					await expect( page.locator( POST_TITLE ) ).toContainText(
+						title
+					);
+				} else {
+					expect( response?.status() ).toBe( 404 );
+					await expect( page.getByText( title ) ).toHaveCount( 0 );
+				}
+			} );
+
+			test( `${ postType.label }: ${
+				expected.canArchive ? 'sees' : 'does not see'
+			} the Archive row action`, async ( { page, requestUtils } ) => {
+				const post = await seedPost( requestUtils, {
+					title: uniqueTitle(
+						`Matrix archive ${ role } ${ postType.key }`
+					),
+					status: 'publish',
+					type: postType.restBase,
+					author: await authorIdFor( requestUtils, role ),
+				} );
+				created.push( { id: post.id, type: postType.restBase } );
+
+				await page.goto(
+					`/wp-admin/edit.php?${ postListQuery( {
+						postType: postType.queryArg,
+					} ) }`
+				);
+
+				if ( ! expected.listsPosts ) {
+					// Core stops the role at the screen itself, before the
+					// plugin is ever consulted — the subscriber for every
+					// type, and the author for `page` specifically (the
+					// stock Author role holds no Page capability at all).
+					// Which wp_die() copy depends on which gate stops them;
+					// see deniedScreenMessage().
+					await expect( page.locator( 'body' ) ).toContainText(
+						deniedScreenMessage( role, postType )
+					);
+					return;
+				}
+
+				// Pin the row first: a "no Archive link" assertion would pass just
+				// as happily against a list that rendered no rows at all.
+				await expect( rowLocator( page, post.id ) ).toBeVisible();
+				await expect(
+					rowActionLocator( page, post.id, 'archive' )
+				).toHaveCount( expected.canArchive ? 1 : 0 );
+			} );
+
+			test( `${ postType.label }: ${
+				expected.canArchive ? 'sees' : 'does not see'
+			} the Unarchive row action`, async ( { page, requestUtils } ) => {
+				const post = await seedPost( requestUtils, {
+					title: uniqueTitle(
+						`Matrix unarchive ${ role } ${ postType.key }`
+					),
+					status: 'publish',
+					type: postType.restBase,
+					author: await authorIdFor( requestUtils, role ),
+				} );
+				created.push( { id: post.id, type: postType.restBase } );
+				await archivePost( requestUtils, post.id );
+
+				await page.goto(
+					`/wp-admin/edit.php?${ postListQuery( {
+						postType: postType.queryArg,
+						postStatus: ARCHIVED_STATUS_SLUG,
+					} ) }`
+				);
+
+				if ( ! expected.listsPosts ) {
+					await expect( page.locator( 'body' ) ).toContainText(
+						deniedScreenMessage( role, postType )
+					);
+					return;
+				}
+
+				await expect( rowLocator( page, post.id ) ).toBeVisible();
+				await expect(
+					rowActionLocator( page, post.id, 'unarchive' )
+				).toHaveCount( expected.canArchive ? 1 : 0 );
+			} );
+		}
+
+		// Deliberately NOT parameterized over POST_TYPES: PostEditorGuard's
+		// map_meta_cap deny (src/Admin/PostEditorGuard.php::deny_editing_archived())
+		// appends an unconditional 'do_not_allow' for any archived post while
+		// read-only mode is active. It keys off post status only — never a
+		// post-type primitive — so every type produces the identical 500 +
+		// message. Looping here would triple the runtime for no signal.
+		test( 'cannot open an archived post in the editor', async ( {
+			page,
+			requestUtils,
+		} ) => {
+			const post = await seedPost( requestUtils, {
+				title: uniqueTitle( `Matrix edit ${ role }` ),
+				status: 'publish',
+				author: await authorIdFor( requestUtils, role ),
+			} );
+			created.push( { id: post.id, type: 'posts' } );
+			await archivePost( requestUtils, post.id );
+
+			const response = await page.goto( editUrl( post.id ) );
+
+			// Read-only mode is on for everybody — no role is an exception.
+			expect( response?.status() ).toBe( 500 );
+			await expect( page.locator( 'body' ) ).toContainText(
+				READ_ONLY_MESSAGE
+			);
+			await expect( page.locator( '#editor' ) ).toHaveCount( 0 );
+		} );
+	} );
+}
+
+test.describe( 'roles: anonymous', () => {
+	test.use( { storageState: { cookies: [], origins: [] } } );
+
+	const created: number[] = [];
+
+	test.afterEach( async ( { requestUtils } ) => {
+		await deletePosts( requestUtils, created.splice( 0 ) );
+	} );
+
+	// Deliberately NOT parameterized over POST_TYPES: ViewCapability's
+	// ownership fallback (author_owns_and_can_edit()) returns false before it
+	// ever reads a post-type primitive, because an anonymous request has no
+	// current user (`$user_id` is always 0) — there is no primitive
+	// resolution here to exercise for any type.
+	test( 'cannot view an archived post on the front end', async ( {
+		page,
+		requestUtils,
+	} ) => {
+		const title = uniqueTitle( 'Matrix view anonymous' );
+		const post = await seedPost( requestUtils, {
+			title,
+			status: 'publish',
+		} );
+		created.push( post.id );
+
+		const archived = await archivePost( requestUtils, post.id );
+		const response = await page.goto( archived.link );
+
+		expect( response?.status() ).toBe( 404 );
+		await expect( page.getByText( title ) ).toHaveCount( 0 );
+	} );
+} );
+
+test.describe( "roles: author on another author's content", () => {
+	test.use( { storageState: storageStatePath( 'author' ) } );
+
+	const created: CreatedPost[] = [];
+
+	test.afterEach( async ( { requestUtils } ) => {
+		await deleteCreated( requestUtils, created.splice( 0 ) );
+	} );
+
+	for ( const postType of POST_TYPES ) {
+		test( `${ postType.label }: cannot view another author's archived post on the front end`, async ( {
+			page,
+			requestUtils,
+		} ) => {
+			const title = uniqueTitle(
+				`Matrix other-author view ${ postType.key }`
+			);
+			// Authored by the admin (user 1) — not the author under test.
+			const post = await seedPost( requestUtils, {
+				title,
+				status: 'publish',
+				type: postType.restBase,
+				author: 1,
+			} );
+			created.push( { id: post.id, type: postType.restBase } );
+
+			const archived = await archivePost( requestUtils, post.id );
+			const response = await page.goto( archived.link );
+
+			expect( response?.status() ).toBe( 404 );
+			await expect( page.getByText( title ) ).toHaveCount( 0 );
+		} );
+	}
+
+	for ( const postType of POST_TYPES ) {
+		test( `${ postType.label }: sees no Archive or Unarchive row action on another author's posts`, async ( {
+			page,
+			requestUtils,
+		} ) => {
+			test.skip(
+				'page' === postType.key,
+				authorUnreachableReason( postType )
+			);
+
+			const active = await seedPost( requestUtils, {
+				title: uniqueTitle(
+					`Matrix other-author archive ${ postType.key }`
+				),
+				status: 'publish',
+				type: postType.restBase,
+				author: 1,
+			} );
+			created.push( { id: active.id, type: postType.restBase } );
+
+			const archivedSeed = await seedPost( requestUtils, {
+				title: uniqueTitle(
+					`Matrix other-author unarchive ${ postType.key }`
+				),
+				status: 'publish',
+				type: postType.restBase,
+				author: 1,
+			} );
+			created.push( { id: archivedSeed.id, type: postType.restBase } );
+			await archivePost( requestUtils, archivedSeed.id );
+
+			await page.goto(
+				`/wp-admin/edit.php?${ postListQuery( {
+					postType: postType.queryArg,
+				} ) }`
+			);
+			await expect( rowLocator( page, active.id ) ).toBeVisible();
+			await expect(
+				rowActionLocator( page, active.id, 'archive' )
+			).toHaveCount( 0 );
+
+			await page.goto(
+				`/wp-admin/edit.php?${ postListQuery( {
+					postType: postType.queryArg,
+					postStatus: ARCHIVED_STATUS_SLUG,
+				} ) }`
+			);
+			await expect( rowLocator( page, archivedSeed.id ) ).toBeVisible();
+			await expect(
+				rowActionLocator( page, archivedSeed.id, 'unarchive' )
+			).toHaveCount( 0 );
+		} );
+	}
+
+	for ( const postType of POST_TYPES ) {
+		test( `${ postType.label }: shows the bulk-select checkbox only on the row the author can unarchive`, async ( {
+			page,
+			requestUtils,
+		} ) => {
+			test.skip(
+				'page' === postType.key,
+				authorUnreachableReason( postType )
+			);
+
+			// PostEditorGuard denies edit_post on every archived post while
+			// read-only mode is active — including to this row's own author's
+			// account, if it belonged to them — so core itself would drop both
+			// checkboxes below. PostList::show_archived_row_checkbox() restores
+			// the checkbox per row, ownership-aware, via
+			// aps_current_user_can_unarchive(). This test pins both outcomes of
+			// that restore in one list view.
+
+			// Foreign: authored by the admin (user 1). The author under test has
+			// neither edit_others_posts nor authorship of this row, so the
+			// restore must not fire and the checkbox must stay absent.
+			const foreign = await seedPost( requestUtils, {
+				title: uniqueTitle(
+					`Matrix other-author checkbox foreign ${ postType.key }`
+				),
+				status: 'publish',
+				type: postType.restBase,
+				author: 1,
+			} );
+			created.push( { id: foreign.id, type: postType.restBase } );
+			await archivePost( requestUtils, foreign.id );
+
+			// Own: authored by the author under test. They hold edit_posts on
+			// their own content, so the restore must fire. Seeded into the same
+			// archived list view as the foreign row above: without this half, a
+			// regression that hid every checkbox unconditionally would pass
+			// silently.
+			const own = await seedPost( requestUtils, {
+				title: uniqueTitle(
+					`Matrix other-author checkbox own ${ postType.key }`
+				),
+				status: 'publish',
+				type: postType.restBase,
+				author: await authorIdFor( requestUtils, 'author' ),
+			} );
+			created.push( { id: own.id, type: postType.restBase } );
+			await archivePost( requestUtils, own.id );
+
+			await page.goto(
+				`/wp-admin/edit.php?${ postListQuery( {
+					postType: postType.queryArg,
+					postStatus: ARCHIVED_STATUS_SLUG,
+				} ) }`
+			);
+
+			// Pin both rows first: a checkbox assertion means nothing against a
+			// row that never rendered.
+			await expect( rowLocator( page, foreign.id ) ).toBeVisible();
+			await expect( rowLocator( page, own.id ) ).toBeVisible();
+
+			await expect( rowCheckboxLocator( page, foreign.id ) ).toHaveCount(
+				0
+			);
+			await expect( rowCheckboxLocator( page, own.id ) ).toHaveCount( 1 );
+		} );
+	}
+} );
+
+// Deliberately NOT parameterized over POST_TYPES: the fixture filter
+// (tests/e2e/fixtures/aps-cap-filter.php) returns the literal 'manage_options'
+// whenever it is enabled, ignoring the default capability it was passed —
+// so it overrides ArchiveCapability's post-type-primitive resolution outright
+// rather than narrowing it. There is no per-type behaviour left to observe
+// once the filter is on.
+test.describe( 'roles: aps_default_*_capability moves the boundary', () => {
+	const created: number[] = [];
+
+	test.beforeEach( async ( { requestUtils } ) => {
+		// Both archive capabilities become `manage_options`.
+		await setFixtures( requestUtils, {
+			[ FIXTURE_TOGGLES.capFilter ]: true,
+		} );
+	} );
+
+	test.afterEach( async ( { requestUtils } ) => {
+		await deletePosts( requestUtils, created.splice( 0 ) );
+		await resetFixtures( requestUtils, [ FIXTURE_TOGGLES.capFilter ] );
+	} );
+
+	test.describe( 'as the editor', () => {
+		test.use( { storageState: storageStatePath( 'editor' ) } );
+
+		test( 'loses both row actions', async ( { page, requestUtils } ) => {
+			const archivable = await seedPost( requestUtils, {
+				title: uniqueTitle( 'Filtered cap editor archivable' ),
+				status: 'publish',
+			} );
+			const archived = await seedPost( requestUtils, {
+				title: uniqueTitle( 'Filtered cap editor archived' ),
+				status: 'publish',
+			} );
+			created.push( archivable.id, archived.id );
+			await archivePost( requestUtils, archived.id );
+
+			await page.goto( `/wp-admin/edit.php?${ postListQuery() }` );
+			// Both rows are still listed to the editor — only the action is
+			// gone. Without this pin the assertions below would survive a
+			// regression that dropped the rows entirely.
+			await expect( rowLocator( page, archivable.id ) ).toBeVisible();
+			await expect(
+				rowActionLocator( page, archivable.id, 'archive' )
+			).toHaveCount( 0 );
+
+			await page.goto(
+				`/wp-admin/edit.php?${ postListQuery( {
+					postStatus: ARCHIVED_STATUS_SLUG,
+				} ) }`
+			);
+			await expect( rowLocator( page, archived.id ) ).toBeVisible();
+			await expect(
+				rowActionLocator( page, archived.id, 'unarchive' )
+			).toHaveCount( 0 );
+		} );
+	} );
+
+	test.describe( 'as the administrator', () => {
+		test( 'keeps both row actions', async ( { page, requestUtils } ) => {
+			const archivable = await seedPost( requestUtils, {
+				title: uniqueTitle( 'Filtered cap admin archivable' ),
+				status: 'publish',
+			} );
+			const archived = await seedPost( requestUtils, {
+				title: uniqueTitle( 'Filtered cap admin archived' ),
+				status: 'publish',
+			} );
+			created.push( archivable.id, archived.id );
+			await archivePost( requestUtils, archived.id );
+
+			// Control for the editor case above: the filter narrowed the
+			// capability, it did not disable the feature.
+			await page.goto( `/wp-admin/edit.php?${ postListQuery() }` );
+			await expect(
+				rowActionLocator( page, archivable.id, 'archive' )
+			).toHaveCount( 1 );
+
+			await page.goto(
+				`/wp-admin/edit.php?${ postListQuery( {
+					postStatus: ARCHIVED_STATUS_SLUG,
+				} ) }`
+			);
+			await expect(
+				rowActionLocator( page, archived.id, 'unarchive' )
+			).toHaveCount( 1 );
+		} );
+	} );
+} );
+
+test.describe( 'roles: aps_default_read_capability moves the boundary', () => {
+	const created: number[] = [];
+
+	test.beforeEach( async ( { requestUtils } ) => {
+		await setFixtures( requestUtils, {
+			[ FIXTURE_TOGGLES.readCapFilter ]: true,
+		} );
+	} );
+
+	test.afterEach( async ( { requestUtils } ) => {
+		await deletePosts( requestUtils, created.splice( 0 ) );
+		await resetFixtures( requestUtils, [ FIXTURE_TOGGLES.readCapFilter ] );
+	} );
+
+	test.describe( 'as the editor', () => {
+		test.use( { storageState: storageStatePath( 'editor' ) } );
+
+		test( 'loses front-end view access to an archived post', async ( {
+			page,
+			requestUtils,
+		} ) => {
+			const title = uniqueTitle( 'Filtered read cap editor view' );
+			// Authored by the admin (default seed author): the editor's own
+			// ownership fallback in ViewCapability must not rescue this case.
+			const post = await seedPost( requestUtils, {
+				title,
+				status: 'publish',
+			} );
+			created.push( post.id );
+			const archived = await archivePost( requestUtils, post.id );
+
+			const response = await page.goto( archived.link );
+
+			expect( response?.status() ).toBe( 404 );
+			await expect( page.getByText( title ) ).toHaveCount( 0 );
+		} );
+
+		// RowActionPolicy::for_post() strips the `view` row action from an
+		// unarchive-eligible row when the viewer cannot view archived
+		// content.
+		test( 'loses the View row action but keeps Unarchive', async ( {
+			page,
+			requestUtils,
+		} ) => {
+			const post = await seedPost( requestUtils, {
+				title: uniqueTitle( 'Filtered read cap editor row action' ),
+				status: 'publish',
+			} );
+			created.push( post.id );
+			await archivePost( requestUtils, post.id );
+
+			await page.goto(
+				`/wp-admin/edit.php?${ postListQuery( {
+					postStatus: ARCHIVED_STATUS_SLUG,
+				} ) }`
+			);
+
+			await expect( rowLocator( page, post.id ) ).toBeVisible();
+			await expect(
+				rowActionLocator( page, post.id, 'unarchive' )
+			).toHaveCount( 1 );
+			await expect(
+				rowActionLocator( page, post.id, 'view' )
+			).toHaveCount( 0 );
+		} );
+	} );
+
+	test.describe( 'as the administrator', () => {
+		// Control for both editor cases above: manage_options is the
+		// administrator's native capability regardless of the filter, so the
+		// boundary move must not cost the administrator any access.
+		test( 'keeps front-end view access to an archived post', async ( {
+			page,
+			requestUtils,
+		} ) => {
+			const title = uniqueTitle( 'Filtered read cap admin view' );
+			const post = await seedPost( requestUtils, {
+				title,
+				status: 'publish',
+			} );
+			created.push( post.id );
+			const archived = await archivePost( requestUtils, post.id );
+
+			const response = await page.goto( archived.link );
+
+			expect( response?.status() ).toBe( 200 );
+			await expect( page.locator( POST_TITLE ) ).toContainText( title );
+		} );
+
+		test( 'keeps the View row action alongside Unarchive', async ( {
+			page,
+			requestUtils,
+		} ) => {
+			const post = await seedPost( requestUtils, {
+				title: uniqueTitle( 'Filtered read cap admin row action' ),
+				status: 'publish',
+			} );
+			created.push( post.id );
+			await archivePost( requestUtils, post.id );
+
+			await page.goto(
+				`/wp-admin/edit.php?${ postListQuery( {
+					postStatus: ARCHIVED_STATUS_SLUG,
+				} ) }`
+			);
+
+			await expect( rowLocator( page, post.id ) ).toBeVisible();
+			await expect(
+				rowActionLocator( page, post.id, 'unarchive' )
+			).toHaveCount( 1 );
+			await expect(
+				rowActionLocator( page, post.id, 'view' )
+			).toHaveCount( 1 );
+		} );
+	} );
+} );

--- a/tests/e2e/specs/settings/read-only-mode.spec.ts
+++ b/tests/e2e/specs/settings/read-only-mode.spec.ts
@@ -1,0 +1,141 @@
+/**
+ * Pins the settings bridge for read-only mode.
+ *
+ * `Settings\HookAdapter` maps the stored `aps_settings['is_read_only']` value
+ * onto the `aps_is_read_only` filter at priority 20, and wires
+ * `Settings\Store::flush_cache()` to the option's add/update/delete hooks so an
+ * external write is picked up without any cache-clearing hack at the call site.
+ *
+ * Both observable consequences of the setting are asserted: the editor guard and
+ * the server-side removal of edit affordances on archived rows.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { test, expect } from '@wordpress/e2e-test-utils-playwright';
+
+/**
+ * Internal dependencies
+ */
+import { editUrl, postListQuery } from '../../config/admin';
+import {
+	archivePost,
+	deletePosts,
+	resetPluginSettings,
+	seedPost,
+	setPluginSettings,
+	uniqueTitle,
+} from '../../config/seed';
+import { pluginStrings } from '../../config/strings';
+import { wpCli } from '../../config/wp-cli';
+
+test.describe( 'settings: read-only mode', () => {
+	const created: number[] = [];
+	let READ_ONLY_MESSAGE: string;
+
+	test.beforeAll( async ( { requestUtils } ) => {
+		( { read_only_message: READ_ONLY_MESSAGE } = await pluginStrings(
+			requestUtils
+		) );
+	} );
+
+	test.afterEach( async ( { requestUtils } ) => {
+		await deletePosts( requestUtils, created.splice( 0 ) );
+		await resetPluginSettings( requestUtils );
+	} );
+
+	test( 'turning the setting off unblocks the editor, turning it on blocks it again', async ( {
+		page,
+		requestUtils,
+	} ) => {
+		const post = await seedPost( requestUtils, {
+			title: uniqueTitle( 'Read only setting' ),
+			status: 'publish',
+		} );
+		created.push( post.id );
+		await archivePost( requestUtils, post.id );
+
+		// Default (no stored setting): read-only is on.
+		let response = await page.goto( editUrl( post.id ) );
+		expect( response?.status() ).toBe( 500 );
+		await expect( page.locator( 'body' ) ).toContainText(
+			READ_ONLY_MESSAGE
+		);
+
+		// Stored false: the very next request behaves differently — no cache
+		// bust, no restart.
+		await setPluginSettings( requestUtils, false );
+		response = await page.goto( editUrl( post.id ) );
+		expect( response?.status() ).toBe( 200 );
+		await expect( page.locator( 'body' ) ).not.toContainText(
+			READ_ONLY_MESSAGE
+		);
+
+		// Stored true: back to blocked.
+		await setPluginSettings( requestUtils, true );
+		response = await page.goto( editUrl( post.id ) );
+		expect( response?.status() ).toBe( 500 );
+		await expect( page.locator( 'body' ) ).toContainText(
+			READ_ONLY_MESSAGE
+		);
+	} );
+
+	test( 'archived rows lose their edit affordances while read-only is on', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		const title = uniqueTitle( 'Read only title link' );
+		const post = await seedPost( requestUtils, {
+			title,
+			status: 'publish',
+		} );
+		created.push( post.id );
+		await archivePost( requestUtils, post.id );
+
+		// Read-only on (default): PostEditorGuard denies edit_post on the
+		// archived row, so core renders the title as plain text — no
+		// row-title link, no Edit or Quick Edit actions. This replaced the
+		// old client-side edit-screen.js DOM stripping.
+		await admin.visitAdminPage(
+			'edit.php',
+			postListQuery( { postStatus: 'archive' } )
+		);
+		const row = page.locator( `#post-${ post.id }` );
+		await expect( row.locator( '.column-title' ) ).toContainText( title );
+		await expect( row.locator( 'a.row-title' ) ).toHaveCount( 0 );
+		await expect( row.locator( '.row-actions .edit' ) ).toHaveCount( 0 );
+		await expect( row.locator( '.row-actions .inline' ) ).toHaveCount( 0 );
+
+		// Read-only off: the title link returns (RowActionPolicy still
+		// strips the Edit/Quick Edit row actions for archived rows).
+		await setPluginSettings( requestUtils, false );
+		await admin.visitAdminPage(
+			'edit.php',
+			postListQuery( { postStatus: 'archive' } )
+		);
+		await expect( row.locator( 'a.row-title' ) ).toHaveCount( 1 );
+	} );
+
+	test( 'an external update_option is visible to Store within the same request', async () => {
+		// The browser assertions above cross a process boundary, where a stale
+		// in-memory cache could never show up. This one runs the write and both
+		// reads inside a single PHP process, which is the only place
+		// Store::flush_cache() can actually be observed.
+		const result = await wpCli( [
+			'eval',
+			'$before = \\ArchivedPostStatus\\Settings\\Store::get( "is_read_only" );' +
+				'update_option( "aps_settings", array( "is_read_only" => false ) );' +
+				'$after = \\ArchivedPostStatus\\Settings\\Store::get( "is_read_only" );' +
+				'echo wp_json_encode( array( "before" => $before, "after" => $after, "filtered" => aps_is_read_only() ) );',
+		] );
+
+		expect( result.exitCode ).toBe( 0 );
+		expect( JSON.parse( result.stdout ) ).toEqual( {
+			before: true,
+			after: false,
+			filtered: false,
+		} );
+	} );
+} );

--- a/tests/e2e/specs/smoke.spec.ts
+++ b/tests/e2e/specs/smoke.spec.ts
@@ -1,0 +1,59 @@
+/**
+ * WordPress dependencies
+ */
+import { test, expect } from '@wordpress/e2e-test-utils-playwright';
+
+/**
+ * Internal dependencies
+ */
+import {
+	ARCHIVED_STATUS_LABEL,
+	ARCHIVED_STATUS_SLUG,
+	ROLE_USERS,
+	storageStatePath,
+} from '../config/roles';
+
+/**
+ * Plugin file as WordPress reports it on the plugins screen.
+ */
+const PLUGIN_FILE = 'archived-post-status/archived-post-status.php';
+
+test.describe( 'e2e harness smoke', () => {
+	test( 'the plugin is active on the plugins screen', async ( {
+		admin,
+		page,
+	} ) => {
+		await admin.visitAdminPage( 'plugins.php' );
+
+		const row = page.locator( `tr[data-plugin="${ PLUGIN_FILE }"]` );
+
+		await expect( row ).toBeVisible();
+		await expect( row ).toHaveClass( /(^|\s)active(\s|$)/ );
+	} );
+
+	test( 'the archived post status is registered', async ( {
+		requestUtils,
+	} ) => {
+		const status = await requestUtils.rest( {
+			path: `/wp/v2/statuses/${ ARCHIVED_STATUS_SLUG }`,
+		} );
+
+		expect( status.slug ).toBe( ARCHIVED_STATUS_SLUG );
+		expect( status.name ).toBe( ARCHIVED_STATUS_LABEL );
+	} );
+} );
+
+test.describe( 'e2e harness smoke — per-role storage state', () => {
+	test.use( { storageState: storageStatePath( 'editor' ) } );
+
+	test( 'the stored editor state signs in as the editor user', async ( {
+		admin,
+		page,
+	} ) => {
+		await admin.visitAdminPage( 'profile.php' );
+
+		await expect( page.locator( '#user_login' ) ).toHaveValue(
+			ROLE_USERS.editor.username
+		);
+	} );
+} );

--- a/tests/e2e/specs/status/poststatusguard.spec.ts
+++ b/tests/e2e/specs/status/poststatusguard.spec.ts
@@ -1,0 +1,319 @@
+/**
+ * Pins `Status\PostStatusGuard`.
+ *
+ * `aps_archive_post()` closes comments and pings as part of archiving. Anything
+ * that sets the archived status with a bare `wp_update_post()` skips that, so
+ * the guard corrects the state on `save_post`. Its documented limit is equally
+ * load-bearing: the bypass path gets state enforcement but no archive meta,
+ * because meta is only written from the `aps_archived_post` action.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { test, expect } from '@wordpress/e2e-test-utils-playwright';
+
+/**
+ * Internal dependencies
+ */
+import { ARCHIVED_STATUS_SLUG } from '../../config/roles';
+import {
+	archivePost,
+	deletePosts,
+	POST_TYPES,
+	postState,
+	rawStatusUpdate,
+	seedPost,
+	unarchivePost,
+	uniqueTitle,
+} from '../../config/seed';
+import type { PostTypeUnderTest } from '../../config/seed';
+import { wpCli } from '../../config/wp-cli';
+
+/**
+ * A post created during a test, tagged with the REST base `deletePosts()`
+ * needs to remove it again.
+ */
+interface CreatedPost {
+	id: number;
+	type: PostTypeUnderTest[ 'restBase' ];
+}
+
+/**
+ * Delete every tracked post, grouped by REST base.
+ *
+ * @param requestUtils Admin request utils.
+ * @param posts        Posts pushed onto the describe block's `created` array.
+ */
+async function deleteCreated(
+	requestUtils: Parameters< typeof deletePosts >[ 0 ],
+	posts: CreatedPost[]
+): Promise< void > {
+	await Promise.all(
+		POST_TYPES.map( ( { restBase } ) =>
+			deletePosts(
+				requestUtils,
+				posts
+					.filter( ( post ) => post.type === restBase )
+					.map( ( post ) => post.id ),
+				restBase
+			)
+		)
+	);
+}
+
+test.describe( 'status: PostStatusGuard corrects direct status writes', () => {
+	const created: CreatedPost[] = [];
+
+	test.afterEach( async ( { requestUtils } ) => {
+		await deleteCreated( requestUtils, created.splice( 0 ) );
+	} );
+
+	test( 'a bare wp_update_post() through WP-CLI gets comments and pings closed', async ( {
+		requestUtils,
+	} ) => {
+		const post = await seedPost( requestUtils, {
+			title: uniqueTitle( 'Guard cli' ),
+			status: 'publish',
+			comment_status: 'open',
+			ping_status: 'open',
+		} );
+		created.push( { id: post.id, type: 'posts' } );
+
+		// Deliberately not `wp post archive` — this is the raw status write the
+		// guard exists to catch.
+		const result = await wpCli( [
+			'eval',
+			`wp_update_post( array( "ID" => ${ post.id }, "post_status" => "${ ARCHIVED_STATUS_SLUG }", ` +
+				'"comment_status" => "open", "ping_status" => "open" ) );' +
+				`clean_post_cache( ${ post.id } );` +
+				`$post = get_post( ${ post.id } );` +
+				'echo wp_json_encode( array( "status" => $post->post_status, ' +
+				'"comment" => $post->comment_status, "ping" => $post->ping_status ) );',
+		] );
+
+		expect( result.exitCode ).toBe( 0 );
+		expect( JSON.parse( result.stdout ) ).toEqual( {
+			status: ARCHIVED_STATUS_SLUG,
+			comment: 'closed',
+			ping: 'closed',
+		} );
+	} );
+
+	for ( const postType of POST_TYPES ) {
+		test( `${ postType.label }: a bare wp_update_post() through a web request gets the same treatment`, async ( {
+			requestUtils,
+		} ) => {
+			const post = await seedPost( requestUtils, {
+				title: uniqueTitle( `Guard web ${ postType.key }` ),
+				status: 'publish',
+				comment_status: 'open',
+				ping_status: 'open',
+				type: postType.restBase,
+			} );
+			created.push( { id: post.id, type: postType.restBase } );
+
+			const after = await rawStatusUpdate( requestUtils, post.id, {
+				post_status: ARCHIVED_STATUS_SLUG,
+				comment_status: 'open',
+				ping_status: 'open',
+			} );
+
+			expect( after.post_status ).toBe( ARCHIVED_STATUS_SLUG );
+			expect( after.comment_status ).toBe( 'closed' );
+			expect( after.ping_status ).toBe( 'closed' );
+		} );
+	}
+
+	test( 'the bypass path writes no archive meta', async ( {
+		requestUtils,
+	} ) => {
+		const post = await seedPost( requestUtils, {
+			title: uniqueTitle( 'Guard meta' ),
+			status: 'publish',
+			comment_status: 'open',
+			ping_status: 'open',
+		} );
+		created.push( { id: post.id, type: 'posts' } );
+
+		const after = await rawStatusUpdate( requestUtils, post.id, {
+			post_status: ARCHIVED_STATUS_SLUG,
+			comment_status: 'open',
+			ping_status: 'open',
+		} );
+
+		// Documented in PostStatusGuard: state is enforced, meta is not written.
+		// It matters downstream — with no snapshot, unarchiving falls back to
+		// the legacy draft/closed/closed default.
+		expect( after.meta.previous_status ).toBe( '' );
+		expect( after.meta.archive_date ).toBe( 0 );
+		expect( after.meta.archive_user ).toBe( 0 );
+	} );
+
+	test( 'a direct write to another status is left alone', async ( {
+		requestUtils,
+	} ) => {
+		const post = await seedPost( requestUtils, {
+			title: uniqueTitle( 'Guard scope' ),
+			status: 'publish',
+			comment_status: 'open',
+			ping_status: 'open',
+		} );
+		created.push( { id: post.id, type: 'posts' } );
+
+		// Control: the guard keys on the archived status, so an ordinary
+		// status change must not close discussion.
+		await rawStatusUpdate( requestUtils, post.id, {
+			post_status: 'draft',
+			comment_status: 'open',
+			ping_status: 'open',
+		} );
+
+		const after = await postState( requestUtils, post.id );
+
+		expect( after.post_status ).toBe( 'draft' );
+		expect( after.comment_status ).toBe( 'open' );
+		expect( after.ping_status ).toBe( 'open' );
+	} );
+
+	test( 'a legacy meta-less archived post unarchives to the draft fallback', async ( {
+		requestUtils,
+	} ) => {
+		const post = await seedPost( requestUtils, {
+			title: uniqueTitle( 'Legacy fallback' ),
+			status: 'publish',
+			comment_status: 'open',
+			ping_status: 'open',
+		} );
+		created.push( { id: post.id, type: 'posts' } );
+
+		// A pre-0.4.0 archive: status set directly, no archive meta written.
+		await rawStatusUpdate( requestUtils, post.id, {
+			post_status: ARCHIVED_STATUS_SLUG,
+			comment_status: 'closed',
+			ping_status: 'closed',
+		} );
+
+		await unarchivePost( requestUtils, post.id );
+		const after = await postState( requestUtils, post.id );
+
+		// With no recorded snapshot, restore falls back to draft/closed/closed.
+		expect( after.post_status ).toBe( 'draft' );
+		expect( after.comment_status ).toBe( 'closed' );
+		expect( after.ping_status ).toBe( 'closed' );
+	} );
+
+	test( 'the aps_unarchive_post_status filter moves the meta-less fallback', async ( {
+		requestUtils,
+	} ) => {
+		const post = await seedPost( requestUtils, {
+			title: uniqueTitle( 'Legacy fallback filter' ),
+			status: 'publish',
+			comment_status: 'open',
+			ping_status: 'open',
+		} );
+		created.push( { id: post.id, type: 'posts' } );
+
+		await rawStatusUpdate( requestUtils, post.id, {
+			post_status: ARCHIVED_STATUS_SLUG,
+			comment_status: 'closed',
+			ping_status: 'closed',
+		} );
+
+		// `wp post unarchive --status` registers a callback on the same
+		// `aps_unarchive_post_status` filter a developer would use, so this
+		// drives the real filter path against real WordPress state.
+		const result = await wpCli( [
+			'post',
+			'unarchive',
+			String( post.id ),
+			'--status=pending',
+		] );
+		expect( result.exitCode ).toBe( 0 );
+
+		const after = await postState( requestUtils, post.id );
+		expect( after.post_status ).toBe( 'pending' );
+	} );
+
+	test( 'a trash round-trip defers the exit, then untrash concludes it cleanly', async ( {
+		requestUtils,
+	} ) => {
+		const post = await seedPost( requestUtils, {
+			title: uniqueTitle( 'Guard trash round-trip' ),
+			status: 'publish',
+			comment_status: 'open',
+			ping_status: 'open',
+		} );
+		created.push( { id: post.id, type: 'posts' } );
+
+		await archivePost( requestUtils, post.id );
+
+		// Trash defers the exit: the meta snapshot survives intact and
+		// comments are NOT reopened while the post sits in trash.
+		const trashResult = await wpCli( [
+			'post',
+			'delete',
+			String( post.id ),
+		] );
+		expect( trashResult.exitCode ).toBe( 0 );
+		const trashed = await postState( requestUtils, post.id );
+		expect( trashed.post_status ).toBe( 'trash' );
+		expect( trashed.comment_status ).toBe( 'closed' );
+		expect( trashed.meta.previous_status ).toBe( 'publish' );
+
+		// Core's untrash lands on draft by default (WP 5.6+). That
+		// concludes the archive lifecycle: the guard restores the
+		// pre-archive discussion state and clears the meta snapshot.
+		const untrashResult = await wpCli( [
+			'eval',
+			`wp_untrash_post( ${ post.id } );`,
+		] );
+		expect( untrashResult.exitCode ).toBe( 0 );
+
+		const untrashed = await postState( requestUtils, post.id );
+		expect( untrashed.post_status ).toBe( 'draft' );
+		expect( untrashed.comment_status ).toBe( 'open' );
+		expect( untrashed.ping_status ).toBe( 'open' );
+		expect( untrashed.meta.previous_status ).toBe( '' );
+		expect( untrashed.meta.archive_date ).toBe( 0 );
+	} );
+
+	test( 'an out-of-band exit from the archived status restores state and clears meta', async ( {
+		requestUtils,
+	} ) => {
+		const post = await seedPost( requestUtils, {
+			title: uniqueTitle( 'Guard exit' ),
+			status: 'publish',
+			comment_status: 'open',
+			ping_status: 'open',
+		} );
+		created.push( { id: post.id, type: 'posts' } );
+
+		// A real 0.4.0 archive: meta snapshot written, discussion closed.
+		await archivePost( requestUtils, post.id );
+		const archived = await postState( requestUtils, post.id );
+		expect( archived.meta.previous_status ).toBe( 'publish' );
+		expect( archived.comment_status ).toBe( 'closed' );
+
+		// Out-of-band exit — core Bulk Edit or any direct status write; the
+		// plugin's UnarchiveOperation never runs.
+		const result = await wpCli( [
+			'post',
+			'update',
+			String( post.id ),
+			'--post_status=publish',
+		] );
+		expect( result.exitCode ).toBe( 0 );
+
+		const after = await postState( requestUtils, post.id );
+
+		// The exit guard restored the discussion snapshot and removed the
+		// now-stale archive meta.
+		expect( after.post_status ).toBe( 'publish' );
+		expect( after.comment_status ).toBe( 'open' );
+		expect( after.ping_status ).toBe( 'open' );
+		expect( after.meta.previous_status ).toBe( '' );
+		expect( after.meta.archive_date ).toBe( 0 );
+		expect( after.meta.archive_user ).toBe( 0 );
+	} );
+} );


### PR DESCRIPTION
Stacked on #49. Base is `release/0.4.0-july-26-refactor`, so this diff is **only** the end-to-end suites — review #49 for the plugin rewrite itself.

## Why this is split out

The release PR carries a rewrite from one 478-line procedural file into ~46 classes. The end-to-end apparatus is another ~7,000 lines on top of that, and reading them together made both harder. Splitting lets the rewrite be reviewed as code and the suites be reviewed as tests.

## What's here

| | |
|---|---|
| `tests/e2e/specs/` | 19 Playwright spec files — **147 tests** (2 skipped) |
| `tests/e2e/config/` | Harness: auth setup, seeding, role storage state, admin helpers, shared strings |
| `tests/e2e/fixtures/` | 10 mu-plugins — a seeding REST API, CPTs with distinct capability shapes, and filter toggles |
| `tests/e2e/cli/run.sh` | Bash CLI suite — **54 assertions** against real `wp` commands |
| `playwright.config.ts` | Single chromium project, `workers: 1` (the suite assumes serial) |
| `.github/workflows/e2e-playwright.yml` | 5 legs: WP latest × PHP 8.1/8.3/8.4, WP 7.0.2 × 8.3, WP master × 8.3 (non-blocking) |
| `tests/bin/set-core-version.js` | Pins the wp-env core version per matrix leg |

## Why the CLI suite came along

It isn't Playwright, but it consumes the same `tests/e2e/fixtures/` mu-plugins and the same `.wp-env.json` mapping. Splitting the drivers from the fixtures would have left neither branch able to run its own tests.

## What it covers

The editor (archive/unarchive round trip, block vs classic, the read-only guard), the front end (404 guard, comments and pings closed, feed and search exclusion, titles), the post list (the Archived column, bulk actions, Quick Edit, row actions), a full role × action capability matrix across post/page/CPT, read-only mode, the deactivation warning, the status guard's defer/conclude trash lifecycle, and the pre-0.4.0 upgrade marker.

Several of these caught things unit tests could not — the bulk-checkbox regression and the untrash-lands-on-draft rule were both found in a real browser against real WordPress.

## Note on dependencies

The Playwright `devDependencies` stay declared on the base branch rather than moving here. Moving them would rewrite `package-lock.json` twice across the stack and desync `npm ci`. Only the three `test:e2e*` scripts and the wp-env mu-plugins mapping move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)